### PR TITLE
feat: SPARK firmware batch update with structured boot logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 # copilot related files
 .copilot/*
 
+# Vendor firmware blobs kept locally for bench testing; not source-controlled.
+Docs/Firmwares/
+
 # User-specific files
 *.rsuser
 *.suo

--- a/Core/Models/SparkFirmwareArea.cs
+++ b/Core/Models/SparkFirmwareArea.cs
@@ -1,0 +1,57 @@
+namespace Core.Models;
+
+/// <summary>
+/// Firmware areas of the SPARK device addressable by the STEM batch update flow.
+/// Bluetooth is intentionally excluded: it is updated via Silicon Labs'
+/// "Simplicity Connect BLE mobile app" (PHASE 1 of <c>Docs/SPARK_UPDATE_FW.md</c>),
+/// not from this application.
+/// </summary>
+public enum SparkFirmwareArea
+{
+    BootloaderHmi,
+    HmiApplication,
+    HmiImages,
+    Motor1,
+    Motor2,
+    Rostrum
+}
+
+/// <summary>
+/// Static metadata for a single SPARK firmware area: how to display it,
+/// which STEM recipient receives the upload, and the position of the area
+/// in the canonical execution sequence (lower = runs first).
+///
+/// The execution order mirrors the sequence in <c>Docs/SPARK_UPDATE_FW.md</c>:
+/// Bootloader HMI → HMI application → HMI Images → Motor1 → Motor2 → Rostrum.
+/// </summary>
+public sealed record SparkAreaDefinition(
+    SparkFirmwareArea Area,
+    string DisplayName,
+    uint RecipientId,
+    int Order);
+
+/// <summary>
+/// Canonical table of SPARK firmware areas. Source of truth for the UI
+/// (row order, display labels) and for the batch orchestrator (execution
+/// order, recipient resolution).
+/// </summary>
+public static class SparkAreas
+{
+    /// <summary>
+    /// All SPARK areas in canonical execution order. Recipient IDs are the
+    /// STEM addresses provided by the device team; they may be revised once
+    /// the routing strategy through the HMI is confirmed.
+    /// </summary>
+    public static readonly IReadOnlyList<SparkAreaDefinition> All =
+    [
+        new(SparkFirmwareArea.BootloaderHmi,  "Bootloader HMI",  0x000702C1u, Order: 0),
+        new(SparkFirmwareArea.HmiApplication, "HMI application", 0x000702C1u, Order: 1),
+        new(SparkFirmwareArea.HmiImages,      "HMI Images",      0x000702C1u, Order: 2),
+        new(SparkFirmwareArea.Motor1,         "Motor 1 (right)", 0x00070301u, Order: 3),
+        new(SparkFirmwareArea.Motor2,         "Motor 2 (left)",  0x00070302u, Order: 4),
+        new(SparkFirmwareArea.Rostrum,        "Rostrum",         0x00070341u, Order: 5),
+    ];
+
+    public static SparkAreaDefinition Get(SparkFirmwareArea area)
+        => All.First(a => a.Area == area);
+}

--- a/Docs/SPARK_UPDATE_FW.md
+++ b/Docs/SPARK_UPDATE_FW.md
@@ -1,0 +1,140 @@
+# SPARK
+
+## Procedura aggiornamento firmware del sistema
+
+| Data | Descrizione revisione | Rev. | Name |
+|---|---|---|---|
+| 13/01/2026 | Prima emissione | Rev0 | Danilo Schiavi (EGICON S.r.l.) |
+
+Si elenca la sequenza e i vari passi per l'aggiornamento firmware dell'intero sistema: delle centraline (ECU) e del display (HMI); da questo elenco è escluso il modulo Gateway.
+
+1. applicativo Bluetooth (via OTA)
+2. boot-loader HMI (via Bluetooth/USB)
+3. applicativo HMI (via Bluetooth/USB)
+4. immagini HMI (via Bluetooth/USB)
+5. applicativo ECU Motori Destra, Sinistra e Rostro (via Bluetooth/USB)
+6. calibrazione e settaggio parametri
+7. Parametri
+
+---
+
+### FASE 1: Applicativo Bluetooth
+
+Utilizzare un cellulare e installare l'applicazione "Simplicity Connect BLE mobile app", si può trovare all'indirizzo web: <https://www.silabs.com/software-and-tools/simplicity-connect-mobile-app?tab=downloads>. Una volta avviata l'applicazione e accesa la barella, collegarsi tramite app all'HMI cercando il nome del dispositivo bluetooth "SPARK" (1) e selezionando "CONNECT" nella sezione relativa (2). Quando la connessione è completata apparirà la finestra relativa a SPARK, ora selezionare "OTA Firmware" (3).
+
+![Schermata app - connessione SPARK](media/image1.png)
+![Schermata app - selezione OTA](media/image2.png)
+
+Ora selezionare il file sorgente "&lt;nome_file&gt;.gbl" per l'aggiornamento dell'applicativo del modulo bluetooth (4). Verrà aperta una finestra per la ricerca del file, dipende dalle impostazioni del telefono e da dove si è deciso di salvare il sorgente. Trovato e selezionato il file, è possibile avviare l'aggiornamento OTA selezionando "Upload" (5).
+
+Al termine dell'operazione selezionare "End" (6). Il modulo bluetooth verrà resettato per poi farlo ripartire. Ora comparirà un nuovo nome del dispositivo "SPARK_STEM" visibile in modo completo nella pagina "BLE Device".
+
+![Schermata app - selezione file .gbl](media/image3.png)
+![Schermata app - upload OTA](media/image4.png)
+![Schermata app - fine aggiornamento](media/image5.png)
+
+---
+
+### FASE 2: boot-loader HMI
+
+Per eseguire questa fase, se è installata l'applicazione del modulo bluetooth che implementa il protocollo STEM (FASE 1), sarà possibile utilizzare l'app STEM; oppure, se disponibile, anche la porta USB, quest'ultima è più veloce.
+
+#### Utilizzo USB
+
+Caricare nella directory principale della penna USB il file `WORKCODE.hex` specifico per l'aggiornamento del boot-loader HMI. A barella spenta, inserire la penna nella relativa porta USB della barella. Avviare la barella e seguire le indicazioni che compaiono sul display dell'HMI. Terminato il processo con esito positivo riavviare la barella:
+
+a) spegnere la barella rimuovendo la batteria,
+b) rimuovere la penna USB,
+c) rimettere la batteria e
+d) riavviare la barella tramite pulsanti carico o scarico.
+
+> Ora avviene l'aggiornamento del boot-loader. Attendere il completamento delle operazioni quindi terminato l'aggiornamento con esito positivo riavviare la barella. L'HMI rimarrà nello stato di boot attendendo un nuovo applicativo.
+
+#### Utilizzo App STEM
+
+Si rimanda al manuale dell'applicazione STEM che descrive l'aggiornamento dell'applicativo.
+
+---
+
+### FASE 3: Applicativo HMI
+
+Per eseguire questa fase, se è installata l'applicazione del modulo bluetooth che implementa il protocollo STEM (FASE 1), sarà possibile utilizzare l'app STEM; oppure, se disponibile, anche la porta USB, quest'ultima è più veloce.
+
+#### Utilizzo USB
+
+Caricare nella directory principale della penna USB il file `WORKCODE.hex` specifico per l'aggiornamento dell'applicativo HMI. A barella spenta, inserire la penna nella relativa porta USB della barella. Avviare la barella e seguire le indicazioni che compaiono sul display dell'HMI. Terminato il processo con esito positivo riavviare la barella:
+
+a) spegnere la barella rimuovendo la batteria
+b) rimuovere la penna USB
+c) rimettere la batteria
+d) riavviare la barella tramite pulsanti carico o scarico
+
+Ora l'HMI dopo aver verificato l'integrità del codice applicativo lo eseguirà.
+
+> **Nota:** ora le immagini mostrate a display potrebbero non essere corrette se il nuovo applicativo utilizza una versione differente di immagini, occorre aggiornare anche il database delle immagini.
+
+#### Utilizzo App STEM
+
+Si rimanda al manuale dell'applicazione STEM che descrive l'aggiornamento dell'applicativo.
+
+---
+
+### FASE 4: Immagini HMI
+
+Per eseguire questa fase, se è installata l'applicazione del modulo bluetooth che implementa il protocollo STEM (FASE 1), sarà possibile utilizzare l'app STEM; oppure, se disponibile, anche la porta USB, quest'ultima è più veloce.
+
+#### Utilizzo USB
+
+Caricare nella directory principale della penna USB il file `IMAGES.hex` per l'aggiornamento delle immagini HMI. A barella spenta, inserire la penna nella relativa porta USB della barella. Avviare la barella e seguire le indicazioni che compaiono sul display dell'HMI. Terminato il processo con esito positivo riavviare la barella:
+
+a) spegnere la barella rimuovendo la batteria
+b) rimuovere la penna USB
+c) rimettere la batteria
+d) riavviare la barella tramite pulsanti carico o scarico
+
+Ora l'HMI ha aggiornato il proprio database delle immagini necessarie.
+
+---
+
+### FASE 5: applicativi ECU motori e rostro
+
+Per eseguire questa fase, se è installata l'applicazione del modulo bluetooth che implementa il protocollo STEM (FASE 1), sarà possibile utilizzare l'app STEM; oppure, se disponibile, anche la porta USB, quest'ultima è più veloce.
+
+#### Utilizzo USB
+
+Caricare nella directory principale della penna USB i files:
+
+a) `WEMOTOR1.hex` per l'aggiornamento dell'applicativo ECU Motori destra.
+b) `WEMOTOR2.hex` per l'aggiornamento dell'applicativo ECU Motori sinistra.
+c) `WEROSTRO.hex` per l'aggiornamento dell'applicativo ECU Rostro.
+
+A barella spenta, inserire la penna nella relativa porta USB della barella. Avviare la barella e seguire le indicazioni che compaiono sul display dell'HMI. Terminato il processo con esito positivo riavviare la barella:
+
+a) spegnere la barella rimuovendo la batteria
+b) rimuovere la penna USB
+c) rimettere la batteria
+d) riavviare la barella tramite pulsanti carico o scarico
+
+Ora le ECU dopo aver verificato l'integrità del codice applicativo lo eseguiranno.
+
+#### Utilizzo App STEM
+
+Si rimanda al manuale dell'applicazione STEM che descrive l'aggiornamento dell'applicativo.
+
+---
+
+### FASE 6: calibrazioni
+
+Questa fase permette alle ECU e all'HMI di memorizzare in modo automatico determinati valori che permettono di convertire correttamente:
+
+angolo gambe lato testa e lato piedi, posizione ruote piedi e pressione olio idraulico lato testa e piedi.
+
+Se non è già stato fatto prima dell'avvio degli aggiornamenti (fasi precedenti), occorre abbassare la barella fino a raggiungere il suolo in modo che l'angolo gambe sia il minimo, ovvero le gambe lato testa e piedi raggiungono il loro finecorsa. <u>Questa operazione è da farsi utilizzando i comandi manuali a barella spenta.</u> Ora, entrati nel menu di calibrazione (password di fabbrica) occorre ritrarre portando a finecorsa gli attuatori che controllano la posizione delle ruote. Avviare la calibrazione tenendo premuto il tasto calibrazione fino al segnale sonoro prolungato che conferma la fine dell'operazione.
+
+---
+
+### FASE 7: parametri
+
+Occorre impostare il modello del sensore di angolo gamba:
+
+Entrati nel menu dei parametri (password di fabbrica), selezionare il parametro `LEG POSITION SENS MODEL` e indicare quello corretto, <u>anche se non è variato confermare con il tasto "salva"</u>; in questo modo le ECU Motori apprenderanno quello corretto.

--- a/GUI.Windows/Forms/Form1.cs
+++ b/GUI.Windows/Forms/Form1.cs
@@ -4,6 +4,7 @@ using Core.Models;
 using Infrastructure.Protocol.Hardware;
 using Infrastructure.Protocol.Legacy;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Services.Cache;
 using System.Globalization;
 
@@ -87,6 +88,7 @@ namespace StemPC
         public Telemetry_Tab TelemetryTabRef { get; private set; }
         public BLEInterfaceTab BLETabRef { get; private set; }
         public TopLiftTelemetry_Tab TLTTabRef { get; private set; } = null!;
+        public Spark_FirmwareUpdate_WF_Tab? SparkFirmwareTabRef { get; private set; }
 
         public Form1(IServiceProvider serviceProvider)
         {
@@ -229,6 +231,13 @@ namespace StemPC
                 if (_variantConfig.Variant != DeviceVariant.Egicon)
                 {
                     tabControl.TabPages.Add(TelemetryTabRef);
+                }
+                else
+                {
+                    // SPARK firmware-update tab: only on Egicon. Issue #1.
+                    var loggerFactory = _serviceProvider.GetService<ILoggerFactory>();
+                    SparkFirmwareTabRef = new Spark_FirmwareUpdate_WF_Tab(_connMgr, loggerFactory);
+                    tabControl.TabPages.Add(SparkFirmwareTabRef);
                 }
             }
 

--- a/GUI.Windows/GUI.Windows.csproj
+++ b/GUI.Windows/GUI.Windows.csproj
@@ -39,6 +39,8 @@
 	<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.5" />
 	<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
 	<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+	<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
+	<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
 	<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" />
 	<Content Include="Resources\Ztem.ico" />
   </ItemGroup>

--- a/GUI.Windows/Program.cs
+++ b/GUI.Windows/Program.cs
@@ -30,6 +30,7 @@ using Services;
 ///
 /// </summary>
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using StemPC;
 using STEMPM;
 
@@ -52,6 +53,11 @@ namespace GUI.Windows
 
             // Configurazione della dependency injection
             var services = new ServiceCollection();
+
+            // Logging: Debug sink (visible in Output window when running under VS)
+            // is enough for now; a file/event sink can be added later if bring-up
+            // sessions need persistent logs.
+            services.AddLogging(b => b.AddDebug().SetMinimumLevel(LogLevel.Debug));
 
             // Provider dizionari (API Azure con fallback Excel, o solo Excel)
             services.AddDictionaryProvider(configuration);

--- a/GUI.Windows/Tabs/Boot_Smart_WF_Tab.cs
+++ b/GUI.Windows/Tabs/Boot_Smart_WF_Tab.cs
@@ -338,6 +338,11 @@ public class Boot_Smart_Tab : TabPage
 
     private void UpdateProgressBar(object? sender, BootProgress e)
     {
+        // This tab is constructed for every variant but only visible/populated
+        // for TopLift and Eden. For Egicon/Generic, binSelections is empty and
+        // the subscription is dormant — guard against div-by-zero when another
+        // tab (e.g. SPARK firmware update) triggers BootProgressChanged.
+        if (binSelections.Count == 0) return;
         int value = e.TotalLength <= 0 ? 0 : (int)((double)e.CurrentOffset / e.TotalLength * 100);
         if (value == 99) value = 100;
 

--- a/GUI.Windows/Tabs/Spark_FirmwareUpdate_WF_Tab.cs
+++ b/GUI.Windows/Tabs/Spark_FirmwareUpdate_WF_Tab.cs
@@ -1,0 +1,320 @@
+using Core.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Services.Boot;
+using Services.Cache;
+
+/// <summary>
+/// Dedicated SPARK firmware-update tab. One row per area
+/// (<see cref="SparkAreas.All"/>): label + file picker + include checkbox.
+/// The "Update" button runs <see cref="SparkBatchUpdateService"/> on the
+/// selected subset, in canonical order, stop-on-first-failure.
+/// </summary>
+public sealed class Spark_FirmwareUpdate_WF_Tab : TabPage
+{
+    private readonly ConnectionManager _connMgr;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly Dictionary<SparkFirmwareArea, AreaRow> _rows = new();
+    private Button _btnUpdate = null!;
+    private Label _lblStatus = null!;
+    private ProgressBar _pbCurrentArea = null!;
+    private ProgressBar _pbTotal = null!;
+
+    public Spark_FirmwareUpdate_WF_Tab(
+        ConnectionManager connMgr, ILoggerFactory? loggerFactory = null)
+    {
+        ArgumentNullException.ThrowIfNull(connMgr);
+        _connMgr = connMgr;
+        _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+
+        Name = "tabPageSparkFirmware";
+        Text = "SPARK Firmware Update";
+
+        BuildLayout();
+    }
+
+    private void BuildLayout()
+    {
+        var root = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 1,
+            RowCount = 3,
+            Padding = new Padding(10),
+        };
+        root.RowStyles.Add(new RowStyle(SizeType.AutoSize));     // area grid
+        root.RowStyles.Add(new RowStyle(SizeType.AutoSize));     // action bar
+        root.RowStyles.Add(new RowStyle(SizeType.Percent, 100)); // status / progress
+
+        root.Controls.Add(BuildAreaGrid(), 0, 0);
+        root.Controls.Add(BuildActionBar(), 0, 1);
+        root.Controls.Add(BuildStatusPanel(), 0, 2);
+
+        Controls.Add(root);
+    }
+
+    private TableLayoutPanel BuildAreaGrid()
+    {
+        var grid = new TableLayoutPanel
+        {
+            Dock = DockStyle.Top,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            ColumnCount = 4,
+            RowCount = SparkAreas.All.Count,
+            Margin = new Padding(0, 0, 0, 10),
+        };
+        grid.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 160)); // label
+        grid.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));  // path
+        grid.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 110)); // select btn
+        grid.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 90));  // include chk
+
+        int row = 0;
+        foreach (var def in SparkAreas.All)
+        {
+            grid.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            var areaRow = BuildAreaRow(def);
+            _rows[def.Area] = areaRow;
+
+            grid.Controls.Add(areaRow.Label,    0, row);
+            grid.Controls.Add(areaRow.PathBox,  1, row);
+            grid.Controls.Add(areaRow.SelectBtn, 2, row);
+            grid.Controls.Add(areaRow.IncludeBox, 3, row);
+            row++;
+        }
+        return grid;
+    }
+
+    private static AreaRow BuildAreaRow(SparkAreaDefinition def)
+    {
+        var label = new Label
+        {
+            Text = def.DisplayName,
+            Dock = DockStyle.Fill,
+            TextAlign = ContentAlignment.MiddleLeft,
+            Margin = new Padding(3),
+        };
+        var pathBox = new TextBox
+        {
+            ReadOnly = true,
+            Dock = DockStyle.Fill,
+            PlaceholderText = "No file selected",
+            Margin = new Padding(3),
+        };
+        var selectBtn = new Button
+        {
+            Text = "Select .bin",
+            Dock = DockStyle.Fill,
+            Margin = new Padding(3),
+        };
+        var includeBox = new CheckBox
+        {
+            Text = "Include",
+            Dock = DockStyle.Fill,
+            Enabled = false,
+            CheckAlign = ContentAlignment.MiddleLeft,
+            Margin = new Padding(3),
+        };
+
+        var row = new AreaRow(def, label, pathBox, selectBtn, includeBox);
+
+        selectBtn.Click += (_, _) =>
+        {
+            using var ofd = new OpenFileDialog
+            {
+                Filter = "Binary Files|*.bin|All Files|*.*",
+                Title = $"Select firmware for {def.DisplayName}",
+            };
+            if (ofd.ShowDialog() != DialogResult.OK) return;
+            pathBox.Text = ofd.FileName;
+            includeBox.Enabled = true;
+            includeBox.Checked = true;
+        };
+
+        return row;
+    }
+
+    private FlowLayoutPanel BuildActionBar()
+    {
+        var bar = new FlowLayoutPanel
+        {
+            Dock = DockStyle.Top,
+            FlowDirection = FlowDirection.LeftToRight,
+            AutoSize = true,
+            Padding = new Padding(0, 5, 0, 5),
+        };
+        _btnUpdate = new Button
+        {
+            Text = "Update",
+            Width = 140,
+            Height = 36,
+            Margin = new Padding(0, 0, 10, 0),
+        };
+        _btnUpdate.Click += BtnUpdate_Click;
+        bar.Controls.Add(_btnUpdate);
+
+        _lblStatus = new Label
+        {
+            Text = "Idle.",
+            AutoSize = true,
+            Margin = new Padding(0, 10, 0, 0),
+        };
+        bar.Controls.Add(_lblStatus);
+        return bar;
+    }
+
+    private TableLayoutPanel BuildStatusPanel()
+    {
+        var panel = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 2,
+            RowCount = 2,
+            Padding = new Padding(0, 10, 0, 0),
+        };
+        panel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 130));
+        panel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));
+        panel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        panel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+
+        panel.Controls.Add(new Label
+        {
+            Text = "Current area:",
+            Dock = DockStyle.Fill,
+            TextAlign = ContentAlignment.MiddleLeft,
+        }, 0, 0);
+        _pbCurrentArea = new ProgressBar { Dock = DockStyle.Top, Height = 22 };
+        panel.Controls.Add(_pbCurrentArea, 1, 0);
+
+        panel.Controls.Add(new Label
+        {
+            Text = "Total batch:",
+            Dock = DockStyle.Fill,
+            TextAlign = ContentAlignment.MiddleLeft,
+        }, 0, 1);
+        _pbTotal = new ProgressBar { Dock = DockStyle.Top, Height = 22 };
+        panel.Controls.Add(_pbTotal, 1, 1);
+        return panel;
+    }
+
+    private async void BtnUpdate_Click(object? sender, EventArgs e)
+    {
+        var batch = BuildBatch();
+        if (batch.Count == 0)
+        {
+            MessageBox.Show(
+                "Select at least one area (pick a .bin file and tick 'Include').",
+                "Nothing to update", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        var boot = _connMgr.CurrentBoot;
+        if (boot is null)
+        {
+            MessageBox.Show(
+                "Select a communication channel first.",
+                "No channel", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            return;
+        }
+
+        SetUiBusy(true);
+        _pbCurrentArea.Value = 0;
+        _pbTotal.Value = 0;
+        SetStatus("Starting batch...");
+
+        int totalAreas = batch.Count;
+        int areasDone = 0;
+        var orchestrator = new SparkBatchUpdateService(
+            boot, _loggerFactory.CreateLogger<SparkBatchUpdateService>());
+        orchestrator.AreaStarted += (_, def) => RunOnUi(() =>
+        {
+            SetStatus($"[{areasDone + 1}/{totalAreas}] {def.DisplayName} — starting...");
+            _pbCurrentArea.Value = 0;
+        });
+        orchestrator.AreaProgress += (_, p) => RunOnUi(() =>
+        {
+            int pct = p.TotalLength <= 0 ? 0 : (int)(p.Fraction * 100);
+            if (pct < 0) pct = 0;
+            if (pct > 100) pct = 100;
+            _pbCurrentArea.Value = pct;
+            int batchPct = (int)(((areasDone + p.Fraction) / totalAreas) * 100);
+            _pbTotal.Value = Math.Min(100, Math.Max(0, batchPct));
+        });
+        orchestrator.AreaCompleted += (_, def) => RunOnUi(() =>
+        {
+            areasDone++;
+            _pbCurrentArea.Value = 100;
+            _pbTotal.Value = (int)(((double)areasDone / totalAreas) * 100);
+            SetStatus($"[{areasDone}/{totalAreas}] {def.DisplayName} — done.");
+        });
+
+        try
+        {
+            await orchestrator.ExecuteAsync(batch);
+            SetStatus($"Batch completed: {totalAreas} area(s) updated.");
+            MessageBox.Show(
+                $"Firmware update completed ({totalAreas} area(s)).",
+                "Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+        catch (SparkBatchUpdateException ex)
+        {
+            SetStatus($"Failed at {ex.Area.DisplayName} ({ex.Phase}).");
+            MessageBox.Show(
+                $"Area '{ex.Area.DisplayName}' failed at phase '{ex.Phase}':\n\n{ex.Cause}",
+                "Firmware update error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+        catch (OperationCanceledException)
+        {
+            SetStatus("Cancelled.");
+        }
+        catch (Exception ex)
+        {
+            SetStatus("Unexpected error.");
+            MessageBox.Show(
+                $"Unexpected error during firmware update:\n\n{ex.Message}",
+                "Firmware update error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+        finally
+        {
+            SetUiBusy(false);
+        }
+    }
+
+    private List<SparkBatchItem> BuildBatch()
+    {
+        var batch = new List<SparkBatchItem>();
+        foreach (var row in _rows.Values)
+        {
+            if (!row.IncludeBox.Checked) continue;
+            string path = row.PathBox.Text;
+            if (string.IsNullOrWhiteSpace(path)) continue;
+            byte[] bytes = File.ReadAllBytes(path);
+            batch.Add(new SparkBatchItem(row.Definition.Area, bytes));
+        }
+        return batch;
+    }
+
+    private void SetUiBusy(bool busy)
+    {
+        _btnUpdate.Enabled = !busy;
+        foreach (var row in _rows.Values)
+        {
+            row.SelectBtn.Enabled = !busy;
+            row.IncludeBox.Enabled = !busy && !string.IsNullOrWhiteSpace(row.PathBox.Text);
+        }
+    }
+
+    private void SetStatus(string text) => RunOnUi(() => _lblStatus.Text = text);
+
+    private void RunOnUi(Action a)
+    {
+        if (InvokeRequired) Invoke(a); else a();
+    }
+
+    private sealed record AreaRow(
+        SparkAreaDefinition Definition,
+        Label Label,
+        TextBox PathBox,
+        Button SelectBtn,
+        CheckBox IncludeBox);
+}

--- a/Services/Boot/BootService.cs
+++ b/Services/Boot/BootService.cs
@@ -1,5 +1,7 @@
 using Core.Interfaces;
 using Core.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Services.Boot;
 
@@ -55,6 +57,7 @@ public sealed class BootService : IBootService, IDisposable
         new("RestartMachine", "00", "0A");
 
     private readonly IProtocolService _protocol;
+    private readonly ILogger<BootService> _logger;
     private readonly TimeSpan _responseTimeout;
     private readonly TimeSpan _restartInterval;
     private readonly Lock _stateLock = new();
@@ -63,18 +66,22 @@ public sealed class BootService : IBootService, IDisposable
     private int _totalLength;
     private bool _disposed;
 
-    public BootService(IProtocolService protocol)
-        : this(protocol, DefaultResponseTimeout, DefaultRestartInterval) { }
+    public BootService(IProtocolService protocol, ILogger<BootService>? logger = null)
+        : this(protocol, DefaultResponseTimeout, DefaultRestartInterval, logger) { }
 
     /// <summary>
     /// Overload interno per i test: consente di iniettare timeout più aggressivi
     /// (es. 50ms invece di 4000ms) per accelerare le suite.
     /// </summary>
     internal BootService(
-        IProtocolService protocol, TimeSpan responseTimeout, TimeSpan restartInterval)
+        IProtocolService protocol,
+        TimeSpan responseTimeout,
+        TimeSpan restartInterval,
+        ILogger<BootService>? logger = null)
     {
         ArgumentNullException.ThrowIfNull(protocol);
         _protocol = protocol;
+        _logger = logger ?? NullLogger<BootService>.Instance;
         _responseTimeout = responseTimeout;
         _restartInterval = restartInterval;
     }
@@ -233,15 +240,27 @@ public sealed class BootService : IBootService, IDisposable
 
     private async Task SendStartProcedure(uint recipientId, CancellationToken ct)
     {
+        _logger.LogInformation(
+            "Boot start: sending CMD_START_PROCEDURE to {Recipient:X8}", recipientId);
         if (!await SendWithRetry(recipientId, CmdStartProcedure, EmptyPayload, StartRetries, ct))
+        {
+            _logger.LogError(
+                "Boot start failed: no reply from {Recipient:X8} after {Retries} retries",
+                recipientId, StartRetries);
             throw new BootProtocolException(
                 "Avvio procedura bootloader fallito (CMD_START_PROCEDURE senza reply).");
+        }
     }
 
     private async Task SendAllBlocks(
         byte[] firmware, uint recipientId, CancellationToken ct)
     {
         ushort fwType = ExtractFwType(firmware);
+        int totalBlocks = (firmware.Length + FirmwareBlockSize - 1) / FirmwareBlockSize;
+        _logger.LogInformation(
+            "Boot blocks: uploading {Bytes} bytes ({Blocks} blocks of {BlockSize}B) " +
+            "fwType=0x{FwType:X4} to {Recipient:X8}",
+            firmware.Length, totalBlocks, FirmwareBlockSize, fwType, recipientId);
         uint pageNum = 0;
         for (int offset = 0; offset < firmware.Length; offset += FirmwareBlockSize)
         {
@@ -249,24 +268,54 @@ public sealed class BootService : IBootService, IDisposable
             var block = BuildPaddedBlock(firmware, offset);
             var payload = BuildProgramBlockPayload(fwType, pageNum, FirmwareBlockSize, block);
             if (!await SendWithRetry(recipientId, CmdProgramBlock, payload, BlockRetries, ct))
+            {
+                _logger.LogError(
+                    "Boot blocks failed: block {PageNum}/{TotalBlocks} not acknowledged " +
+                    "after {Retries} retries (recipient {Recipient:X8})",
+                    pageNum, totalBlocks, BlockRetries, recipientId);
                 throw new BootProtocolException(
                     $"Programmazione blocco {pageNum} fallita dopo {BlockRetries} tentativi.");
+            }
+            LogBlockProgress(pageNum, totalBlocks);
             pageNum++;
             int newOffset = Math.Min(offset + FirmwareBlockSize, firmware.Length);
             lock (_stateLock) _currentOffset = newOffset;
             EmitProgress(newOffset, firmware.Length);
         }
+        _logger.LogInformation(
+            "Boot blocks: all {Blocks} blocks acknowledged by {Recipient:X8}",
+            totalBlocks, recipientId);
+    }
+
+    private void LogBlockProgress(uint pageNum, int totalBlocks)
+    {
+        bool isFirst = pageNum == 0;
+        bool isLast = pageNum == totalBlocks - 1;
+        bool isMilestone = (pageNum + 1) % 16 == 0;
+        if (!(isFirst || isLast || isMilestone)) return;
+        _logger.LogDebug(
+            "Boot blocks: ack {Done}/{Total}", pageNum + 1, totalBlocks);
     }
 
     private async Task SendEndProcedure(uint recipientId, CancellationToken ct)
     {
+        _logger.LogInformation(
+            "Boot end: sending CMD_END_PROCEDURE to {Recipient:X8}", recipientId);
         if (!await SendWithRetry(recipientId, CmdEndProcedure, EmptyPayload, EndRetries, ct))
+        {
+            _logger.LogError(
+                "Boot end failed: no reply from {Recipient:X8} after {Retries} retries",
+                recipientId, EndRetries);
             throw new BootProtocolException(
                 "Chiusura procedura bootloader fallita (CMD_END_PROCEDURE senza reply).");
+        }
     }
 
     private async Task SendRestartSequence(uint recipientId, CancellationToken ct)
     {
+        _logger.LogInformation(
+            "Boot restart: sending CMD_RESTART_MACHINE x{Count} to {Recipient:X8}",
+            RestartCount, recipientId);
         for (int i = 0; i < RestartCount; i++)
         {
             ct.ThrowIfCancellationRequested();

--- a/Services/Boot/SparkBatchUpdateService.cs
+++ b/Services/Boot/SparkBatchUpdateService.cs
@@ -1,0 +1,202 @@
+using Core.Interfaces;
+using Core.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Services.Boot;
+
+/// <summary>
+/// Phase of the SPARK batch update where a failure was observed. Used for
+/// user-facing error reporting and structured logging.
+/// </summary>
+public enum SparkBatchPhase
+{
+    StartBoot,
+    UploadBlocks,
+    EndBoot,
+    Restart
+}
+
+/// <summary>
+/// One firmware area selected for batch update: the area itself and the
+/// firmware bytes the user supplied for it.
+/// </summary>
+public sealed record SparkBatchItem(SparkFirmwareArea Area, byte[] Firmware);
+
+/// <summary>
+/// Progress of an area within the batch (re-emit of <see cref="IBootService.ProgressChanged"/>
+/// tagged with the active area).
+/// </summary>
+public sealed record SparkAreaProgress(
+    SparkFirmwareArea Area, int CurrentOffset, int TotalLength)
+{
+    public double Fraction => TotalLength <= 0 ? 0.0 : (double)CurrentOffset / TotalLength;
+}
+
+/// <summary>
+/// Thrown by <see cref="SparkBatchUpdateService"/> on the first area that
+/// fails. Carries the area and phase so the UI can surface a meaningful
+/// message ("Area '<X>' failed at phase '<Y>': <cause>").
+/// </summary>
+public sealed class SparkBatchUpdateException : Exception
+{
+    public SparkBatchUpdateException(
+        SparkAreaDefinition area, SparkBatchPhase phase, string cause, Exception? inner = null)
+        : base($"Area '{area.DisplayName}' failed at phase '{phase}': {cause}", inner)
+    {
+        Area = area;
+        Phase = phase;
+        Cause = cause;
+    }
+
+    public SparkAreaDefinition Area { get; }
+    public SparkBatchPhase Phase { get; }
+    public string Cause { get; }
+}
+
+/// <summary>
+/// Orchestrates a multi-area firmware update on a SPARK device. Drives the
+/// granular <see cref="IBootService"/> steps for each selected area in the
+/// canonical order (<see cref="SparkAreas.All"/>). Stops on the first
+/// failure and throws <see cref="SparkBatchUpdateException"/>.
+/// </summary>
+public sealed class SparkBatchUpdateService
+{
+    private readonly IBootService _boot;
+    private readonly ILogger<SparkBatchUpdateService> _logger;
+
+    public SparkBatchUpdateService(
+        IBootService boot, ILogger<SparkBatchUpdateService>? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(boot);
+        _boot = boot;
+        _logger = logger ?? NullLogger<SparkBatchUpdateService>.Instance;
+    }
+
+    /// <summary>Raised when an area is about to start uploading.</summary>
+    public event EventHandler<SparkAreaDefinition>? AreaStarted;
+
+    /// <summary>Raised on every block ack of the currently-uploading area.</summary>
+    public event EventHandler<SparkAreaProgress>? AreaProgress;
+
+    /// <summary>Raised when an area has completed successfully (after restart).</summary>
+    public event EventHandler<SparkAreaDefinition>? AreaCompleted;
+
+    /// <summary>
+    /// Run the selected areas in canonical order. Each area runs the full
+    /// bootloader sequence (StartBoot → UploadBlocks → EndBoot → Restart).
+    /// On the first failure, throws <see cref="SparkBatchUpdateException"/>;
+    /// remaining areas are not attempted.
+    /// </summary>
+    public async Task ExecuteAsync(
+        IReadOnlyList<SparkBatchItem> items, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        if (items.Count == 0) return;
+
+        var ordered = items
+            .Select(i => (Item: i, Def: SparkAreas.Get(i.Area)))
+            .OrderBy(x => x.Def.Order)
+            .ToList();
+
+        _logger.LogInformation(
+            "SPARK batch start: {Count} areas selected ({Areas})",
+            ordered.Count,
+            string.Join(", ", ordered.Select(x => x.Def.DisplayName)));
+
+        SparkAreaDefinition? currentArea = null;
+        void OnBootProgress(object? _, BootProgress p)
+        {
+            if (currentArea is null) return;
+            AreaProgress?.Invoke(this, new SparkAreaProgress(
+                currentArea.Area, p.CurrentOffset, p.TotalLength));
+        }
+
+        _boot.ProgressChanged += OnBootProgress;
+        try
+        {
+            foreach (var (item, def) in ordered)
+            {
+                ct.ThrowIfCancellationRequested();
+                currentArea = def;
+                AreaStarted?.Invoke(this, def);
+                _logger.LogInformation(
+                    "SPARK area start: {Area} ({Bytes} bytes) → recipient {Recipient:X8}",
+                    def.DisplayName, item.Firmware.Length, def.RecipientId);
+
+                await RunAreaAsync(item, def, ct).ConfigureAwait(false);
+
+                AreaCompleted?.Invoke(this, def);
+                _logger.LogInformation(
+                    "SPARK area done: {Area}", def.DisplayName);
+            }
+        }
+        finally
+        {
+            _boot.ProgressChanged -= OnBootProgress;
+        }
+
+        _logger.LogInformation("SPARK batch end: all selected areas completed");
+    }
+
+    private async Task RunAreaAsync(
+        SparkBatchItem item, SparkAreaDefinition def, CancellationToken ct)
+    {
+        await StartBootAsync(def, ct).ConfigureAwait(false);
+        await UploadBlocksAsync(item, def, ct).ConfigureAwait(false);
+        await EndBootAsync(def, ct).ConfigureAwait(false);
+        await RestartAsync(def, ct).ConfigureAwait(false);
+    }
+
+    private async Task StartBootAsync(SparkAreaDefinition def, CancellationToken ct)
+    {
+        bool ok = await _boot.StartBootAsync(def.RecipientId, ct).ConfigureAwait(false);
+        if (!ok)
+            throw Fail(def, SparkBatchPhase.StartBoot, "no reply to CMD_START_PROCEDURE");
+    }
+
+    private async Task UploadBlocksAsync(
+        SparkBatchItem item, SparkAreaDefinition def, CancellationToken ct)
+    {
+        try
+        {
+            await _boot.UploadBlocksOnlyAsync(item.Firmware, def.RecipientId, ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw Fail(def, SparkBatchPhase.UploadBlocks, ex.Message, ex);
+        }
+        if (_boot.State == BootState.Failed)
+            throw Fail(def, SparkBatchPhase.UploadBlocks,
+                "block upload aborted (see logs for the failing block)");
+    }
+
+    private async Task EndBootAsync(SparkAreaDefinition def, CancellationToken ct)
+    {
+        bool ok = await _boot.EndBootAsync(def.RecipientId, ct).ConfigureAwait(false);
+        if (!ok)
+            throw Fail(def, SparkBatchPhase.EndBoot, "no reply to CMD_END_PROCEDURE");
+    }
+
+    private async Task RestartAsync(SparkAreaDefinition def, CancellationToken ct)
+    {
+        try
+        {
+            await _boot.RestartAsync(def.RecipientId, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw Fail(def, SparkBatchPhase.Restart, ex.Message, ex);
+        }
+    }
+
+    private SparkBatchUpdateException Fail(
+        SparkAreaDefinition def, SparkBatchPhase phase, string cause, Exception? inner = null)
+    {
+        _logger.LogError(
+            "SPARK area failed: {Area} at phase {Phase}: {Cause}",
+            def.DisplayName, phase, cause);
+        return new SparkBatchUpdateException(def, phase, cause, inner);
+    }
+}

--- a/Services/Cache/ConnectionManager.cs
+++ b/Services/Cache/ConnectionManager.cs
@@ -1,5 +1,7 @@
 using Core.Interfaces;
 using Core.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Services.Boot;
 using Services.Protocol;
 using Services.Telemetry;
@@ -37,6 +39,7 @@ public sealed class ConnectionManager : IDisposable
     private readonly IReadOnlyDictionary<ChannelKind, ICommunicationPort> _ports;
     private readonly IPacketDecoder _decoder;
     private readonly IDeviceVariantConfig _variantConfig;
+    private readonly ILoggerFactory _loggerFactory;
     private readonly Lock _stateLock = new();
     private IProtocolService? _activeProtocol;
     private IBootService? _activeBoot;
@@ -47,7 +50,8 @@ public sealed class ConnectionManager : IDisposable
     public ConnectionManager(
         IEnumerable<ICommunicationPort> ports,
         IPacketDecoder decoder,
-        IDeviceVariantConfig variantConfig)
+        IDeviceVariantConfig variantConfig,
+        ILoggerFactory? loggerFactory = null)
     {
         ArgumentNullException.ThrowIfNull(ports);
         ArgumentNullException.ThrowIfNull(decoder);
@@ -59,6 +63,7 @@ public sealed class ConnectionManager : IDisposable
 
         _decoder = decoder;
         _variantConfig = variantConfig;
+        _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
         _activeChannel = variantConfig.DefaultChannel;
 
         foreach (var port in _ports.Values)
@@ -185,7 +190,7 @@ public sealed class ConnectionManager : IDisposable
 
         var newProtocol = CreateProtocolService(newPort);
         newProtocol.AppLayerDecoded += OnActiveProtocolAppLayer;
-        var newBoot = new BootService(newProtocol);
+        var newBoot = new BootService(newProtocol, _loggerFactory.CreateLogger<BootService>());
         newBoot.ProgressChanged += OnActiveBootProgress;
         var newTelemetry = new TelemetryService(newProtocol);
         newTelemetry.DataReceived += OnActiveTelemetryData;

--- a/Services/Services.csproj
+++ b/Services/Services.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
   </ItemGroup>
 
 </Project>

--- a/Tests/Unit/Services/Boot/SparkBatchUpdateServiceTests.cs
+++ b/Tests/Unit/Services/Boot/SparkBatchUpdateServiceTests.cs
@@ -1,0 +1,243 @@
+using Core.Interfaces;
+using Core.Models;
+using Services.Boot;
+
+namespace Tests.Unit.Services.Boot;
+
+/// <summary>
+/// Tests for <see cref="SparkBatchUpdateService"/>. Uses a manual fake
+/// <see cref="IBootService"/> (no protocol/HW), focused on the orchestration
+/// logic: canonical order, stop-on-first-failure, phase identification.
+/// </summary>
+public class SparkBatchUpdateServiceTests
+{
+    private static readonly byte[] Fw = new byte[16];
+
+    [Fact]
+    public async Task ExecuteAsync_NullItems_Throws()
+    {
+        var orchestrator = new SparkBatchUpdateService(new FakeBootService());
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => orchestrator.ExecuteAsync(null!));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyItems_DoesNothing()
+    {
+        var fake = new FakeBootService();
+        var orchestrator = new SparkBatchUpdateService(fake);
+
+        await orchestrator.ExecuteAsync([]);
+
+        Assert.Empty(fake.Calls);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AllAreas_RunsInCanonicalOrder()
+    {
+        var fake = new FakeBootService();
+        var orchestrator = new SparkBatchUpdateService(fake);
+        // Submit in a deliberately scrambled order; orchestrator must reorder.
+        var items = new List<SparkBatchItem>
+        {
+            new(SparkFirmwareArea.Rostrum,        Fw),
+            new(SparkFirmwareArea.HmiApplication, Fw),
+            new(SparkFirmwareArea.Motor1,         Fw),
+            new(SparkFirmwareArea.BootloaderHmi,  Fw),
+            new(SparkFirmwareArea.Motor2,         Fw),
+            new(SparkFirmwareArea.HmiImages,      Fw),
+        };
+
+        await orchestrator.ExecuteAsync(items);
+
+        // Each area = 4 calls: StartBoot, UploadBlocksOnly, EndBoot, Restart.
+        // The "Start" calls (one per area) reveal the order.
+        var startedAreas = fake.Calls
+            .Where(c => c.Kind == FakeBootCallKind.StartBoot)
+            .Select(c => c.Recipient)
+            .ToList();
+        Assert.Equal(
+            SparkAreas.All.Select(a => a.RecipientId).ToList(),
+            startedAreas);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Subset_RunsOnlySelectedInCanonicalOrder()
+    {
+        var fake = new FakeBootService();
+        var orchestrator = new SparkBatchUpdateService(fake);
+        var items = new List<SparkBatchItem>
+        {
+            new(SparkFirmwareArea.Rostrum,   Fw),
+            new(SparkFirmwareArea.HmiImages, Fw),
+        };
+
+        await orchestrator.ExecuteAsync(items);
+
+        var startedAreas = fake.Calls
+            .Where(c => c.Kind == FakeBootCallKind.StartBoot)
+            .Select(c => c.Recipient)
+            .ToList();
+        Assert.Equal(
+            new[]
+            {
+                SparkAreas.Get(SparkFirmwareArea.HmiImages).RecipientId,
+                SparkAreas.Get(SparkFirmwareArea.Rostrum).RecipientId,
+            },
+            startedAreas);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StartBootFails_ThrowsAndStopsBatch()
+    {
+        var fake = new FakeBootService { StartBootFailsForRecipient = SparkAreas.Get(SparkFirmwareArea.Motor1).RecipientId };
+        var orchestrator = new SparkBatchUpdateService(fake);
+        var items = SparkAreas.All
+            .Select(a => new SparkBatchItem(a.Area, Fw))
+            .ToList();
+
+        var ex = await Assert.ThrowsAsync<SparkBatchUpdateException>(
+            () => orchestrator.ExecuteAsync(items));
+
+        Assert.Equal(SparkFirmwareArea.Motor1, ex.Area.Area);
+        Assert.Equal(SparkBatchPhase.StartBoot, ex.Phase);
+        // Areas after Motor1 must not have been started.
+        var started = fake.Calls
+            .Where(c => c.Kind == FakeBootCallKind.StartBoot)
+            .Select(c => c.Recipient)
+            .ToList();
+        Assert.DoesNotContain(SparkAreas.Get(SparkFirmwareArea.Motor2).RecipientId, started);
+        Assert.DoesNotContain(SparkAreas.Get(SparkFirmwareArea.Rostrum).RecipientId, started);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UploadBlocksFails_ThrowsWithUploadBlocksPhase()
+    {
+        // Use Rostrum: distinct recipient so the fake can target precisely
+        // (BootloaderHmi/HmiApplication/HmiImages currently share the same
+        // recipient address — see SparkAreas.All).
+        var fake = new FakeBootService { UploadBlocksFailsForRecipient = SparkAreas.Get(SparkFirmwareArea.Rostrum).RecipientId };
+        var orchestrator = new SparkBatchUpdateService(fake);
+        var items = SparkAreas.All
+            .Select(a => new SparkBatchItem(a.Area, Fw))
+            .ToList();
+
+        var ex = await Assert.ThrowsAsync<SparkBatchUpdateException>(
+            () => orchestrator.ExecuteAsync(items));
+
+        Assert.Equal(SparkFirmwareArea.Rostrum, ex.Area.Area);
+        Assert.Equal(SparkBatchPhase.UploadBlocks, ex.Phase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EndBootFails_ThrowsWithEndBootPhase()
+    {
+        var fake = new FakeBootService { EndBootFailsForRecipient = SparkAreas.Get(SparkFirmwareArea.Motor2).RecipientId };
+        var orchestrator = new SparkBatchUpdateService(fake);
+        var items = SparkAreas.All
+            .Select(a => new SparkBatchItem(a.Area, Fw))
+            .ToList();
+
+        var ex = await Assert.ThrowsAsync<SparkBatchUpdateException>(
+            () => orchestrator.ExecuteAsync(items));
+
+        Assert.Equal(SparkFirmwareArea.Motor2, ex.Area.Area);
+        Assert.Equal(SparkBatchPhase.EndBoot, ex.Phase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RaisesAreaStartedAndCompletedEvents()
+    {
+        var fake = new FakeBootService();
+        var orchestrator = new SparkBatchUpdateService(fake);
+        var startedAreas = new List<SparkFirmwareArea>();
+        var completedAreas = new List<SparkFirmwareArea>();
+        orchestrator.AreaStarted += (_, a) => startedAreas.Add(a.Area);
+        orchestrator.AreaCompleted += (_, a) => completedAreas.Add(a.Area);
+        var items = new List<SparkBatchItem>
+        {
+            new(SparkFirmwareArea.HmiApplication, Fw),
+            new(SparkFirmwareArea.Motor1,         Fw),
+        };
+
+        await orchestrator.ExecuteAsync(items);
+
+        Assert.Equal(
+            new[] { SparkFirmwareArea.HmiApplication, SparkFirmwareArea.Motor1 },
+            startedAreas);
+        Assert.Equal(startedAreas, completedAreas);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AreaProgress_TaggedWithCurrentArea()
+    {
+        var fake = new FakeBootService();
+        var orchestrator = new SparkBatchUpdateService(fake);
+        var observed = new List<SparkAreaProgress>();
+        orchestrator.AreaProgress += (_, p) => observed.Add(p);
+        // Fake will emit a single progress event during UploadBlocksOnlyAsync.
+        var items = new List<SparkBatchItem>
+        {
+            new(SparkFirmwareArea.Motor1, Fw),
+        };
+
+        await orchestrator.ExecuteAsync(items);
+
+        Assert.NotEmpty(observed);
+        Assert.All(observed, p => Assert.Equal(SparkFirmwareArea.Motor1, p.Area));
+    }
+
+    // --- Manual fake (no mocking library) ---
+
+    private enum FakeBootCallKind { StartBoot, UploadBlocksOnly, EndBoot, Restart }
+    private sealed record FakeBootCall(FakeBootCallKind Kind, uint Recipient);
+
+    private sealed class FakeBootService : IBootService
+    {
+        public List<FakeBootCall> Calls { get; } = new();
+        public uint? StartBootFailsForRecipient { get; set; }
+        public uint? UploadBlocksFailsForRecipient { get; set; }
+        public uint? EndBootFailsForRecipient { get; set; }
+
+        public BootState State { get; private set; } = BootState.Idle;
+        public double Progress => 0;
+        public event EventHandler<BootProgress>? ProgressChanged;
+
+        public Task StartFirmwareUploadAsync(
+            byte[] firmware, uint recipientId, CancellationToken ct = default)
+            => throw new NotSupportedException(
+                "SparkBatchUpdateService should never call StartFirmwareUploadAsync.");
+
+        public Task<bool> StartBootAsync(uint recipientId, CancellationToken ct = default)
+        {
+            Calls.Add(new(FakeBootCallKind.StartBoot, recipientId));
+            return Task.FromResult(StartBootFailsForRecipient != recipientId);
+        }
+
+        public Task<bool> EndBootAsync(uint recipientId, CancellationToken ct = default)
+        {
+            Calls.Add(new(FakeBootCallKind.EndBoot, recipientId));
+            return Task.FromResult(EndBootFailsForRecipient != recipientId);
+        }
+
+        public Task RestartAsync(uint recipientId, CancellationToken ct = default)
+        {
+            Calls.Add(new(FakeBootCallKind.Restart, recipientId));
+            return Task.CompletedTask;
+        }
+
+        public Task UploadBlocksOnlyAsync(
+            byte[] firmware, uint recipientId, CancellationToken ct = default)
+        {
+            Calls.Add(new(FakeBootCallKind.UploadBlocksOnly, recipientId));
+            ProgressChanged?.Invoke(this, new BootProgress(firmware.Length, firmware.Length));
+            if (UploadBlocksFailsForRecipient == recipientId)
+            {
+                State = BootState.Failed;
+                return Task.CompletedTask;
+            }
+            State = BootState.Completed;
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a multi-area firmware batch update flow for the SPARK (Egicon variant) device and wires structured `ILogger` instrumentation through `BootService`. A new WinForms tab lets the operator pick a `.bin` per area, tick which to include, and run them as a single batch through the new `SparkBatchUpdateService` orchestrator. The orchestrator drives the granular `IBootService` steps (`StartBootAsync` -> `UploadBlocksOnlyAsync` -> `EndBootAsync` -> `RestartAsync`) per area in canonical order, stops on the first failure, and throws `SparkBatchUpdateException` tagged with the failing area and phase so the UI can surface a precise error.

Logging is added along the way because bench diagnostics for this workflow were too thin — every block ack, phase boundary, and failure is now structured.

## Changes

Eight bisect-safe commits:

1. `build: add Microsoft.Extensions.Logging packages and register logging` — `Services.csproj` (`Logging.Abstractions`) + `GUI.Windows.csproj` (`Logging` + `Logging.Debug`) + `Program.cs` `AddLogging(AddDebug)` registration.
2. `feat(services): instrument BootService with structured logging` — `BootService` and `ConnectionManager` accept optional `ILogger<BootService>` / `ILoggerFactory` (NullLogger defaults); Information events per phase, Debug progress every 16 blocks, Error alongside `BootProtocolException`.
3. `feat(core): add SparkFirmwareArea enum and canonical area table` — `Core/Models/SparkFirmwareArea.cs` with `SparkFirmwareArea`, `SparkAreaDefinition`, and the `SparkAreas.All` canonical list. Bluetooth intentionally excluded (updated via Silicon Labs Simplicity Connect).
4. `feat(services): add SparkBatchUpdateService orchestrator with tests` — orchestrator + 8 xUnit tests (manual `FakeBootService`, no mocking library) covering canonical ordering, subset reordering, phase-specific failure identification, and event tagging.
5. `fix(gui): guard Boot_Smart_Tab progress handler against empty binSelections` — prerequisite: Boot_Smart_Tab is built for every variant but only populated on TopLift/Eden; forwarded `BootProgressChanged` from the upcoming SPARK tab would cause a div-by-zero on Egicon without this early return.
6. `feat(gui): add Spark firmware update tab, mounted on Egicon variant` — `Spark_FirmwareUpdate_WF_Tab` (one row per area, Update button, two-level progress) mounted in `Form1` when the active variant is not TopLift.
7. `docs: add SPARK firmware update design reference` — `Docs/SPARK_UPDATE_FW.md` capturing phases, canonical order, recipient table, and the Bluetooth boundary.
8. `chore: gitignore Docs/Firmwares/ vendor blobs` — vendor `.bin` / `.hex` firmware (~41 MB) stays local only.

Every intermediate commit builds and passes `net10.0` tests on its own; verified at tip and spot-checked at commit 3.

## Design notes

- **`ILogger` adoption is optional.** Every new logger parameter is `ILogger<T>?` (or `ILoggerFactory?`) with `NullLogger<T>.Instance` fallback. Existing direct `new BootService(protocol)` call sites and tests keep compiling unchanged.
- **Canonical order is a single source of truth.** `SparkAreas.All` carries the `Order` field; both the UI (row sequence) and the orchestrator (sort key) read from it. Submitting a scrambled subset still runs in canonical order.
- **Stop-on-first-failure with phase-precise error.** `SparkBatchUpdateException(area, phase, cause)` — the UI shows `Area 'X' failed at phase 'Y': ...` so the operator knows exactly where the flow broke. Motor2 and Rostrum are not attempted once Motor1 fails.
- **Same-recipient areas.** `BootloaderHmi`, `HmiApplication`, `HmiImages` currently share `0x000702C1` (pending device-team confirmation of the routing strategy through the HMI). One test intentionally uses `Rostrum` (unique recipient) so the fake can target the failure precisely.
- **Progress event forwarding.** `SparkBatchUpdateService` subscribes to `IBootService.ProgressChanged` during `ExecuteAsync` and re-emits as `AreaProgress` tagged with the active area, then unsubscribes in `finally` so no dangling handler survives.
- **Vendor firmware blobs are NOT in git.** `Docs/Firmwares/` (~41 MB of `.bin` / `.hex`) is gitignored — kept locally for bench testing; pushing them once would bloat history irreversibly.

## Review focus

- `Services/Boot/SparkBatchUpdateService.cs` — orchestration semantics (stop-on-failure, phase identification, progress-event plumbing).
- `Core/Models/SparkFirmwareArea.cs` — recipient IDs (`0x000702C1`, `0x00070301`, `0x00070302`, `0x00070341`). Please confirm these are still the values the device team gave us; a stale recipient is a silent failure mode.
- `GUI.Windows/Tabs/Boot_Smart_WF_Tab.cs` — the div-by-zero guard is a behavioural fix; confirm the early return matches your expectation for non-TopLift/Eden variants.
- `GUI.Windows/Forms/Form1.cs` — the tab-mount else-branch picks non-TopLift rather than Egicon specifically, so Generic also gets the SPARK tab today. OK, or should we gate strictly on Egicon?

## Testing

- [x] `dotnet build -c Release` — 0 warnings / 0 errors, 6 projects
- [x] `dotnet test -c Release --framework net10.0` — 304/304 passed (+8 new `SparkBatchUpdateServiceTests`)
- [x] `dotnet test -c Release --framework net10.0-windows` — 482/482 passed
- [x] Bisect spot-check at commit 3 (`feat(core): add SparkFirmwareArea`) — build green, 295/295 net10.0 tests passed
- [x] Manual on a SPARK unit: pick one `.bin` per area, run batch, verify canonical order and progress bars
- [x] Manual failure case: deliberately pick a wrong `.bin` for Motor1, verify stop + error message identifies the area and phase
