### PR TITLE
chore: bootstrap Lean 4 tooling at Lean/ root (T001)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -371,3 +371,8 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Lean 4 / Lake build artifacts
+Lean/.lake/
+Lean/lakefile.olean
+Lean/lake-packages/

--- a/Lean/Phase2/BatchComposition.lean
+++ b/Lean/Phase2/BatchComposition.lean
@@ -1,0 +1,5 @@
+import Mathlib
+
+namespace Phase2.BatchComposition
+
+end Phase2.BatchComposition

--- a/Lean/Phase2/BleLifecycle.lean
+++ b/Lean/Phase2/BleLifecycle.lean
@@ -1,0 +1,5 @@
+import Mathlib
+
+namespace Phase2.BleLifecycle
+
+end Phase2.BleLifecycle

--- a/Lean/Phase2/BootStateMachine.lean
+++ b/Lean/Phase2/BootStateMachine.lean
@@ -1,0 +1,5 @@
+import Mathlib
+
+namespace Phase2.BootStateMachine
+
+end Phase2.BootStateMachine

--- a/Lean/lakefile.lean
+++ b/Lean/lakefile.lean
@@ -1,0 +1,10 @@
+import Lake
+open Lake DSL
+
+package «stem»
+
+require «mathlib» from git
+  "https://github.com/leanprover-community/mathlib4.git" @ "v4.15.0"
+
+@[default_target]
+lean_lib «Phase2»

--- a/Lean/lean-toolchain
+++ b/Lean/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.15.0

--- a/specs/001-spark-ble-fw-stabilize/tasks.md
+++ b/specs/001-spark-ble-fw-stabilize/tasks.md
@@ -33,7 +33,7 @@ description: "Task list for implementing spec 001 Spark BLE Firmware Stabilizati
 
 **Purpose**: Bootstrap the Lean 4 toolchain (no prior material in repo) and add FsCheck to the test project. Enables every downstream task that produces a Lean definition or a property test.
 
-- [ ] T001 [P] Bootstrap Lean 4 tooling at repo root: create `Lean/lean-toolchain` pinned to `leanprover/lean4:v4.15.0` (per research.md R1); create `Lean/lakefile.lean` with mathlib4 dependency; create empty skeleton files `Lean/Phase2/BootStateMachine.lean`, `Lean/Phase2/BleLifecycle.lean`, `Lean/Phase2/BatchComposition.lean` (module declarations + `import Mathlib` only). Add `Lean/.lake/`, `Lean/lakefile.olean`, and `Lean/lake-packages/` to `.gitignore`.
+- [x] T001 [P] Bootstrap Lean 4 tooling at repo root: create `Lean/lean-toolchain` pinned to `leanprover/lean4:v4.15.0` (per research.md R1); create `Lean/lakefile.lean` with mathlib4 dependency; create empty skeleton files `Lean/Phase2/BootStateMachine.lean`, `Lean/Phase2/BleLifecycle.lean`, `Lean/Phase2/BatchComposition.lean` (module declarations + `import Mathlib` only). Add `Lean/.lake/`, `Lean/lakefile.olean`, and `Lean/lake-packages/` to `.gitignore`.
 - [ ] T002 [P] Add `FsCheck.Xunit` package version `3.1.0` to `Tests/Tests.csproj` (research.md R2). Add a smoke test `Tests/Unit/FsCheckSmokeTests.cs` on `net10.0` that exercises one trivial `[Property]` to confirm the dependency resolves and xUnit discovers FsCheck tests.
 
 ---


### PR DESCRIPTION
## Summary

Implements **T001** of spec-001 — minimal Lake project at the new `Lean/` root, unblocking T005 (Phase 2 state-machine definitions) and the rest of the Lean track.

## Files

- `Lean/lean-toolchain` — pinned to `leanprover/lean4:v4.15.0` per research.md R1.
- `Lean/lakefile.lean` — Lake DSL, mathlib4 v4.15.0 git dependency, default target `Phase2`.
- `Lean/Phase2/{BootStateMachine,BleLifecycle,BatchComposition}.lean` — namespace skeletons with `import Mathlib` only.
- `.gitignore` — adds `Lean/.lake/`, `Lean/lakefile.olean`, `Lean/lake-packages/`.

## Verification

This PR creates files only — it does **not** run `lake update` or `lake build`. T005 is the first task that exercises the build (and the spec requires `lake build` MUST pass at that point). On a fresh checkout, T005 will need:

```powershell
cd Lean
lake update    # downloads mathlib4, generates lake-manifest.json
lake build
```

`lake-manifest.json` will be committed by T005 (or earlier if helpful).

## Note on toolchain version

Spec pins `v4.15.0` (decision date: spec authoring time). Currently installed local toolchain is `v4.30.tmp`. Sticking to spec; if the team wants to bump the pin to a newer stable, that's a research.md amendment, not a T001 change.

## Depends on

- #40 (rename `Specs/` → `Lean/`) — merged.

## Unblocks

- T005 (Phase 2 type definitions)
- All downstream Lean tasks: T022, T023, T024.