### PR TITLE
chore: add FsCheck.Xunit 3.1.0 + smoke test (T002)

### DIFF
--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FsCheck.Xunit" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />

--- a/Tests/Unit/FsCheckSmokeTests.cs
+++ b/Tests/Unit/FsCheckSmokeTests.cs
@@ -1,0 +1,9 @@
+using FsCheck.Xunit;
+
+namespace Tests.Unit;
+
+public class FsCheckSmokeTests
+{
+    [Property]
+    public bool IntegerAddition_IsCommutative(int a, int b) => a + b == b + a;
+}

--- a/specs/001-spark-ble-fw-stabilize/tasks.md
+++ b/specs/001-spark-ble-fw-stabilize/tasks.md
@@ -34,7 +34,7 @@ description: "Task list for implementing spec 001 Spark BLE Firmware Stabilizati
 **Purpose**: Bootstrap the Lean 4 toolchain (no prior material in repo) and add FsCheck to the test project. Enables every downstream task that produces a Lean definition or a property test.
 
 - [x] T001 [P] Bootstrap Lean 4 tooling at repo root: create `Lean/lean-toolchain` pinned to `leanprover/lean4:v4.15.0` (per research.md R1); create `Lean/lakefile.lean` with mathlib4 dependency; create empty skeleton files `Lean/Phase2/BootStateMachine.lean`, `Lean/Phase2/BleLifecycle.lean`, `Lean/Phase2/BatchComposition.lean` (module declarations + `import Mathlib` only). Add `Lean/.lake/`, `Lean/lakefile.olean`, and `Lean/lake-packages/` to `.gitignore`.
-- [ ] T002 [P] Add `FsCheck.Xunit` package version `3.1.0` to `Tests/Tests.csproj` (research.md R2). Add a smoke test `Tests/Unit/FsCheckSmokeTests.cs` on `net10.0` that exercises one trivial `[Property]` to confirm the dependency resolves and xUnit discovers FsCheck tests.
+- [x] T002 [P] Add `FsCheck.Xunit` package version `3.1.0` to `Tests/Tests.csproj` (research.md R2). Add a smoke test `Tests/Unit/FsCheckSmokeTests.cs` on `net10.0` that exercises one trivial `[Property]` to confirm the dependency resolves and xUnit discovers FsCheck tests.
 
 ---
 


### PR DESCRIPTION
## Summary

Implements **T002** of spec-001 — adds `FsCheck.Xunit` 3.1.0 to the test project and a trivial `[Property]` smoke test confirming xUnit discovers FsCheck-based tests.

## Files

- `Tests/Tests.csproj` — adds `<PackageReference Include="FsCheck.Xunit" Version="3.1.0" />`.
- `Tests/Unit/FsCheckSmokeTests.cs` — single `[Property]` (`IntegerAddition_IsCommutative`).

## Verification

Local runs (both TFMs):

```
dotnet test --framework net10.0                  → 305/305 passed (was 304)
dotnet test --framework net10.0-windows10.0.19041.0 (smoke filter) → 1/1 passed
```

CI runs `--framework net10.0` only.

## Notes

Per `research.md` R2, FsCheck.Xunit 3.x is the current major; 2.x is in maintenance. Manual `Arbitrary<T>` generators (under `Tests/Unit/Generators/`) come later — this PR only confirms the package resolves and integrates with xUnit.

Closes #12.