### PR TITLE
feat: add structured logging scopes for FR-009 (T003)

### DIFF
--- a/Services/Boot/BootService.cs
+++ b/Services/Boot/BootService.cs
@@ -114,15 +114,16 @@ public sealed class BootService : IBootService, IDisposable
         ThrowIfDisposed();
         ValidateFirmware(firmware);
 
-        BeginUpload(firmware.Length);
+        const string step = "StartFirmwareUpload";
+        BeginUpload(firmware.Length, recipientId, step);
         try
         {
             await RunUploadSequence(firmware, recipientId, ct).ConfigureAwait(false);
-            CompleteUpload();
+            CompleteUpload(recipientId, step);
         }
         catch (OperationCanceledException)
         {
-            FailUpload();
+            FailUpload(recipientId, step);
             throw;
         }
         catch (BootProtocolException)
@@ -130,11 +131,11 @@ public sealed class BootService : IBootService, IDisposable
             // Fallimento di protocollo (timeout reply) — stato Failed, niente
             // rethrow (parità col legacy BootManager che mostrava MessageBox e
             // ritornava). L'osservabilità del fallimento avviene tramite State.
-            FailUpload();
+            FailUpload(recipientId, step);
         }
         catch
         {
-            FailUpload();
+            FailUpload(recipientId, step);
             throw;
         }
     }
@@ -167,24 +168,25 @@ public sealed class BootService : IBootService, IDisposable
         ThrowIfDisposed();
         ValidateFirmware(firmware);
 
-        BeginUpload(firmware.Length);
+        const string step = "UploadBlocksOnly";
+        BeginUpload(firmware.Length, recipientId, step);
         try
         {
             await SendAllBlocks(firmware, recipientId, ct).ConfigureAwait(false);
-            CompleteUpload();
+            CompleteUpload(recipientId, step);
         }
         catch (OperationCanceledException)
         {
-            FailUpload();
+            FailUpload(recipientId, step);
             throw;
         }
         catch (BootProtocolException)
         {
-            FailUpload();
+            FailUpload(recipientId, step);
         }
         catch
         {
-            FailUpload();
+            FailUpload(recipientId, step);
             throw;
         }
     }
@@ -205,28 +207,59 @@ public sealed class BootService : IBootService, IDisposable
         _disposed = true;
     }
 
-    private void BeginUpload(int totalLength)
+    private void BeginUpload(int totalLength, uint recipientId, string step)
     {
+        BootState old;
         lock (_stateLock)
         {
             if (_state == BootState.Uploading)
                 throw new InvalidOperationException(
                     "Upload firmware già in corso.");
+            old = _state;
             _state = BootState.Uploading;
             _currentOffset = 0;
             _totalLength = totalLength;
         }
+        LogTransition(old, BootState.Uploading, recipientId, step);
         EmitProgress(0, totalLength);
     }
 
-    private void CompleteUpload()
+    private void CompleteUpload(uint recipientId, string step)
     {
-        lock (_stateLock) _state = BootState.Completed;
+        BootState old;
+        bool changed;
+        lock (_stateLock)
+        {
+            old = _state;
+            changed = old != BootState.Completed;
+            _state = BootState.Completed;
+        }
+        if (changed) LogTransition(old, BootState.Completed, recipientId, step);
     }
 
-    private void FailUpload()
+    private void FailUpload(uint recipientId, string step)
     {
-        lock (_stateLock) _state = BootState.Failed;
+        BootState old;
+        bool changed;
+        lock (_stateLock)
+        {
+            old = _state;
+            changed = old != BootState.Failed;
+            _state = BootState.Failed;
+        }
+        if (changed) LogTransition(old, BootState.Failed, recipientId, step);
+    }
+
+    private void LogTransition(BootState old, BootState newState, uint recipientId, string step)
+    {
+        using var scope = _logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["Area"] = "Boot",
+            ["Step"] = step,
+            ["Attempt"] = 0,
+            ["Recipient"] = recipientId
+        });
+        _logger.LogInformation("BootState {Old} -> {New}", old, newState);
     }
 
     private async Task RunUploadSequence(
@@ -332,6 +365,15 @@ public sealed class BootService : IBootService, IDisposable
         for (int i = 0; i < retries; i++)
         {
             ct.ThrowIfCancellationRequested();
+            using var scope = _logger.BeginScope(new Dictionary<string, object?>
+            {
+                ["Area"] = "Boot",
+                ["Step"] = command.Name,
+                ["Attempt"] = i + 1,
+                ["Recipient"] = recipientId
+            });
+            if (i > 0)
+                _logger.LogWarning("Retrying {Step}", command.Name);
             bool ok = await _protocol.SendCommandAndWaitReplyAsync(
                 recipientId,
                 command,

--- a/Services/Cache/ConnectionManager.cs
+++ b/Services/Cache/ConnectionManager.cs
@@ -40,6 +40,7 @@ public sealed class ConnectionManager : IDisposable
     private readonly IPacketDecoder _decoder;
     private readonly IDeviceVariantConfig _variantConfig;
     private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger<ConnectionManager> _logger;
     private readonly Lock _stateLock = new();
     private IProtocolService? _activeProtocol;
     private IBootService? _activeBoot;
@@ -64,6 +65,7 @@ public sealed class ConnectionManager : IDisposable
         _decoder = decoder;
         _variantConfig = variantConfig;
         _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+        _logger = _loggerFactory.CreateLogger<ConnectionManager>();
         _activeChannel = variantConfig.DefaultChannel;
 
         foreach (var port in _ports.Values)
@@ -202,7 +204,20 @@ public sealed class ConnectionManager : IDisposable
             _activeTelemetry = newTelemetry;
         }
         if (previousChannel != target || oldProtocol is null)
+        {
+            using (_logger.BeginScope(new Dictionary<string, object?>
+            {
+                ["Area"] = "Connection",
+                ["Step"] = "SwitchTo",
+                ["Attempt"] = 0,
+                ["Recipient"] = null
+            }))
+            {
+                _logger.LogInformation(
+                    "ActiveChannel {Previous} -> {Target}", previousChannel, target);
+            }
             ActiveChannelChanged?.Invoke(this, target);
+        }
     }
 
     /// <summary>
@@ -229,6 +244,19 @@ public sealed class ConnectionManager : IDisposable
             _activeTelemetry = null;
         }
         DisposeActiveServices(protocol, boot, telemetry);
+        if (protocol is not null)
+        {
+            using (_logger.BeginScope(new Dictionary<string, object?>
+            {
+                ["Area"] = "Connection",
+                ["Step"] = "Disconnect",
+                ["Attempt"] = 0,
+                ["Recipient"] = null
+            }))
+            {
+                _logger.LogInformation("ActiveChannel {Channel} disconnected", current);
+            }
+        }
         if (_ports.TryGetValue(current, out var port))
             await port.DisconnectAsync(ct).ConfigureAwait(false);
     }
@@ -275,10 +303,18 @@ public sealed class ConnectionManager : IDisposable
 
     private void OnPortStateChanged(object? sender, ConnectionState state)
     {
-        if (sender is ICommunicationPort port)
+        if (sender is not ICommunicationPort port) return;
+        using (_logger.BeginScope(new Dictionary<string, object?>
         {
-            StateChanged?.Invoke(this, new ConnectionStateSnapshot(port.Kind, state));
+            ["Area"] = "Connection",
+            ["Step"] = "PortStateChanged",
+            ["Attempt"] = 0,
+            ["Recipient"] = port.Kind
+        }))
+        {
+            _logger.LogInformation("Port {Channel} state -> {State}", port.Kind, state);
         }
+        StateChanged?.Invoke(this, new ConnectionStateSnapshot(port.Kind, state));
     }
 
     private void OnActiveProtocolAppLayer(object? sender, AppLayerDecodedEvent evt)

--- a/specs/001-spark-ble-fw-stabilize/tasks.md
+++ b/specs/001-spark-ble-fw-stabilize/tasks.md
@@ -44,7 +44,7 @@ description: "Task list for implementing spec 001 Spark BLE Firmware Stabilizati
 
 **⚠️ CRITICAL**: User stories can start in parallel only AFTER Phase 2 completes.
 
-- [ ] T003 Add structured logging scopes (FR-009, research.md R11) to `Services/Boot/BootService.cs` and `Services/Cache/ConnectionManager.cs`: every state transition emits exactly one `LogInformation` line; every retry emits exactly one `LogWarning`; both use `BeginScope` with `{ Area, Step, Attempt, Recipient }`. Depends on: nothing.
+- [x] T003 Add structured logging scopes (FR-009, research.md R11) to `Services/Boot/BootService.cs` and `Services/Cache/ConnectionManager.cs`: every state transition emits exactly one `LogInformation` line; every retry emits exactly one `LogWarning`; both use `BeginScope` with `{ Area, Step, Attempt, Recipient }`. Depends on: nothing.
 - [ ] T004 [P] Add Debug-configuration shutdown-audit logger `GUI.Windows/Diagnostics/ShutdownAudit.cs` (research.md R8): logs every `IDisposable` owned by `ConnectionManager`, `BootService`, `BLEManager` at dispose time with stack-trace. Wired in `GUI.Windows/Program.cs` under `#if DEBUG`. Depends on: nothing.
 - [ ] T005 Define Lean 4 state-machine types and transitions (no preservation theorems yet) in `Lean/Phase2/BootStateMachine.lean`, `Lean/Phase2/BleLifecycle.lean`, `Lean/Phase2/BatchComposition.lean`. Exact shapes per `data-model.md`. `lake build` MUST pass. Depends on: T001.
 


### PR DESCRIPTION
## Summary

Implements **T003** — structured logging hooks for FR-009 in `BootService` and `ConnectionManager`. Each state transition emits exactly one `LogInformation`; each retry emits exactly one `LogWarning`. All emissions are wrapped in `BeginScope({ Area, Step, Attempt, Recipient })` per research.md R11.

## Changes

**`Services/Boot/BootService.cs`** (+57 / -15)
- `BeginUpload` / `CompleteUpload` / `FailUpload` now take `recipientId` + `step`. Idempotent: only logs on actual state change.
- New `LogTransition` helper: one `Info` per transition inside a `BeginScope`.
- `SendWithRetry` wraps each iteration in a per-attempt scope (`Attempt = i + 1`). Emits one `Warning` when `i > 0`.

**`Services/Cache/ConnectionManager.cs`** (+38 / -2)
- New `ILogger<ConnectionManager>` field (built from existing `ILoggerFactory`).
- `SwitchToAsync` logs the `ActiveChannel {Previous} -> {Target}` transition (gated by the same `previousChannel != target || oldProtocol is null` condition that fires `ActiveChannelChanged`).
- `DisconnectAsync` logs `ActiveChannel {Channel} disconnected` when a protocol was attached.
- `OnPortStateChanged` logs every port state change with `Recipient = port.Kind`.

## Verification

- `dotnet test --framework net10.0`: **305 / 305 passed** (unchanged from main).
- `dotnet test --framework net10.0-windows10.0.19041.0`: **483 / 483 passed**.
- No public API changes; logger defaults to `NullLogger` so existing tests need no fixture updates.

## Design notes (per the design discussion)

1. `Recipient = null` on `Connection.SwitchTo` / `Connection.Disconnect` scopes — confirmed.
2. `Step = "PortStateChanged"` (not split per port) — confirmed.
3. `Attempt = 0` on non-retry scopes — confirmed.

Closes #13.