### PR TITLE
feat: add Debug-only shutdown audit logger (T004)

### DIFF
--- a/Core/Diagnostics/ShutdownAuditHook.cs
+++ b/Core/Diagnostics/ShutdownAuditHook.cs
@@ -1,0 +1,27 @@
+namespace Core.Diagnostics;
+
+/// <summary>
+/// Minimal cross-layer hook used by the Debug-configuration shutdown audit
+/// (spec-001 T004, research.md R8). Services and Infrastructure layers call
+/// <see cref="Record"/> inside their Dispose methods; the composition root
+/// (GUI.Windows) installs an <see cref="OnDispose"/> callback that attaches a
+/// stack-trace and writes a log line.
+/// </summary>
+/// <remarks>
+/// Intentionally a static with a nullable delegate so that Release builds and
+/// any environment that does not wire up a sink incur zero overhead and no
+/// allocations. No dependency on <c>Microsoft.Extensions.Logging</c> — Core
+/// stays dependency-free.
+/// </remarks>
+public static class ShutdownAuditHook
+{
+    /// <summary>
+    /// Callback invoked for each recorded disposal. Parameters: owner type
+    /// name, disposed field description. Null (default) means no-op.
+    /// </summary>
+    public static Action<string, string>? OnDispose { get; set; }
+
+    /// <summary>Record a disposal event. No-op when <see cref="OnDispose"/> is null.</summary>
+    public static void Record(string ownerName, string fieldDescription)
+        => OnDispose?.Invoke(ownerName, fieldDescription);
+}

--- a/GUI.Windows/Diagnostics/ShutdownAudit.cs
+++ b/GUI.Windows/Diagnostics/ShutdownAudit.cs
@@ -1,0 +1,32 @@
+using Core.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace GUI.Windows.Diagnostics;
+
+/// <summary>
+/// Debug-only shutdown audit sink (spec-001 T004, research.md R8). When
+/// enabled, every disposal recorded through <see cref="ShutdownAuditHook"/>
+/// produces one <see cref="LogLevel.Debug"/> line with the call-site stack
+/// trace, so that the US1 close/relaunch investigation (T006) can correlate
+/// "disposed at X" with "reused at Y".
+/// </summary>
+public static class ShutdownAudit
+{
+    /// <summary>
+    /// Install the audit sink. Call from <c>Program.Main</c> guarded by
+    /// <c>#if DEBUG</c>. Idempotent: a second call replaces the previous sink.
+    /// </summary>
+    public static void Enable(ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ShutdownAuditHook.OnDispose = (owner, field) =>
+        {
+            logger.LogDebug(
+                "[ShutdownAudit] {Owner} disposing {Field}\nStack:\n{Stack}",
+                owner, field, Environment.StackTrace);
+        };
+    }
+
+    /// <summary>Remove the audit sink (hook becomes a no-op again).</summary>
+    public static void Disable() => ShutdownAuditHook.OnDispose = null;
+}

--- a/GUI.Windows/Program.cs
+++ b/GUI.Windows/Program.cs
@@ -33,6 +33,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using StemPC;
 using STEMPM;
+#if DEBUG
+using GUI.Windows.Diagnostics;
+#endif
 
 namespace GUI.Windows
 {
@@ -85,6 +88,17 @@ namespace GUI.Windows
             // Provider di servizi per dependency injection
             var serviceProvider = services.BuildServiceProvider();
 
+#if DEBUG
+            // spec-001 T004 (research.md R8): Debug-only shutdown audit.
+            // Logs every IDisposable owned by ConnectionManager, BootService,
+            // BLEManager at dispose time with stack-trace. Disposing the
+            // service provider on exit ensures singleton IDisposables run
+            // through the audit; Release builds keep the previous behavior.
+            ShutdownAudit.Enable(
+                serviceProvider.GetRequiredService<ILoggerFactory>()
+                    .CreateLogger("GUI.Windows.Diagnostics.ShutdownAudit"));
+#endif
+
             // To customize application configuration such as set high DPI settings or default font,
             // see https://aka.ms/applicationconfiguration.
             ApplicationConfiguration.Initialize();
@@ -99,7 +113,16 @@ namespace GUI.Windows
             Form1 mainForm = new(serviceProvider);
             mainForm.Load += (sender, e) => splash.Close(); // Chiude la splash screen all'avvio del MainForm
 
-            Application.Run(mainForm);
+            try
+            {
+                Application.Run(mainForm);
+            }
+            finally
+            {
+#if DEBUG
+                serviceProvider.Dispose();
+#endif
+            }
         }
     }
 }

--- a/Infrastructure.Protocol/Legacy/BLE_Manager.cs
+++ b/Infrastructure.Protocol/Legacy/BLE_Manager.cs
@@ -3,6 +3,7 @@ using Plugin.BLE.Abstractions;
 using Plugin.BLE.Abstractions.Contracts;
 using Plugin.BLE.Abstractions.EventArgs;
 using System.Diagnostics;
+using Core.Diagnostics;
 using Infrastructure.Protocol.Hardware;
 
 namespace Infrastructure.Protocol.Legacy
@@ -12,8 +13,10 @@ namespace Infrastructure.Protocol.Legacy
     /// Vive in Legacy/ perché è un driver di transizione: sarà rimpiazzato
     /// quando Stem.Communication NuGet sarà disponibile. Nessuna dipendenza da UI.
     /// </summary>
-    public class BLEManager : IBleDriver
+    public class BLEManager : IBleDriver, IDisposable
     {
+        private bool _disposed;
+
         /// <summary>
         /// Evento che viene sollevato quando viene scoperto un nuovo dispositivo BLE.
         /// Il parametro è il nome del dispositivo.
@@ -414,6 +417,20 @@ namespace Infrastructure.Protocol.Legacy
             {
                 return ble.State.ToString();
             }
+        }
+
+        /// <summary>
+        /// Minimal <see cref="IDisposable"/> implementation wired for spec-001
+        /// T004 (research.md R8): allows the Debug-only shutdown audit to
+        /// observe BLEManager's disposal. Actual cleanup of Plugin.BLE adapter
+        /// event handlers and connected-device handles is deferred to T007
+        /// (US1 root-cause fix).
+        /// </summary>
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            ShutdownAuditHook.Record(nameof(BLEManager), "(self)");
         }
     }
 }

--- a/Services/Boot/BootService.cs
+++ b/Services/Boot/BootService.cs
@@ -1,3 +1,4 @@
+using Core.Diagnostics;
 using Core.Interfaces;
 using Core.Models;
 using Microsoft.Extensions.Logging;
@@ -205,6 +206,7 @@ public sealed class BootService : IBootService, IDisposable
     {
         if (_disposed) return;
         _disposed = true;
+        ShutdownAuditHook.Record(nameof(BootService), "(self)");
     }
 
     private void BeginUpload(int totalLength, uint recipientId, string step)

--- a/Services/Cache/ConnectionManager.cs
+++ b/Services/Cache/ConnectionManager.cs
@@ -1,3 +1,4 @@
+using Core.Diagnostics;
 using Core.Interfaces;
 using Core.Models;
 using Microsoft.Extensions.Logging;
@@ -274,6 +275,7 @@ public sealed class ConnectionManager : IDisposable
         _activeProtocol = null;
         _activeBoot = null;
         _activeTelemetry = null;
+        ShutdownAuditHook.Record(nameof(ConnectionManager), "(self)");
     }
 
     /// <summary>
@@ -294,11 +296,28 @@ public sealed class ConnectionManager : IDisposable
     {
         if (telemetry is not null) telemetry.DataReceived -= OnActiveTelemetryData;
         if (boot is not null) boot.ProgressChanged -= OnActiveBootProgress;
-        (telemetry as IDisposable)?.Dispose();
-        (boot as IDisposable)?.Dispose();
+        if (telemetry is IDisposable td)
+        {
+            ShutdownAuditHook.Record(
+                nameof(ConnectionManager),
+                $"ActiveTelemetry ({telemetry.GetType().Name})");
+            td.Dispose();
+        }
+        if (boot is IDisposable bd)
+        {
+            ShutdownAuditHook.Record(
+                nameof(ConnectionManager),
+                $"ActiveBoot ({boot.GetType().Name})");
+            bd.Dispose();
+        }
         if (protocol is not null)
+        {
             protocol.AppLayerDecoded -= OnActiveProtocolAppLayer;
-        protocol?.Dispose();
+            ShutdownAuditHook.Record(
+                nameof(ConnectionManager),
+                $"ActiveProtocol ({protocol.GetType().Name})");
+            protocol.Dispose();
+        }
     }
 
     private void OnPortStateChanged(object? sender, ConnectionState state)

--- a/specs/001-spark-ble-fw-stabilize/tasks.md
+++ b/specs/001-spark-ble-fw-stabilize/tasks.md
@@ -45,7 +45,7 @@ description: "Task list for implementing spec 001 Spark BLE Firmware Stabilizati
 **⚠️ CRITICAL**: User stories can start in parallel only AFTER Phase 2 completes.
 
 - [x] T003 Add structured logging scopes (FR-009, research.md R11) to `Services/Boot/BootService.cs` and `Services/Cache/ConnectionManager.cs`: every state transition emits exactly one `LogInformation` line; every retry emits exactly one `LogWarning`; both use `BeginScope` with `{ Area, Step, Attempt, Recipient }`. Depends on: nothing.
-- [ ] T004 [P] Add Debug-configuration shutdown-audit logger `GUI.Windows/Diagnostics/ShutdownAudit.cs` (research.md R8): logs every `IDisposable` owned by `ConnectionManager`, `BootService`, `BLEManager` at dispose time with stack-trace. Wired in `GUI.Windows/Program.cs` under `#if DEBUG`. Depends on: nothing.
+- [x] T004 [P] Add Debug-configuration shutdown-audit logger `GUI.Windows/Diagnostics/ShutdownAudit.cs` (research.md R8): logs every `IDisposable` owned by `ConnectionManager`, `BootService`, `BLEManager` at dispose time with stack-trace. Wired in `GUI.Windows/Program.cs` under `#if DEBUG`. Depends on: nothing.
 - [ ] T005 Define Lean 4 state-machine types and transitions (no preservation theorems yet) in `Lean/Phase2/BootStateMachine.lean`, `Lean/Phase2/BleLifecycle.lean`, `Lean/Phase2/BatchComposition.lean`. Exact shapes per `data-model.md`. `lake build` MUST pass. Depends on: T001.
 
 **Checkpoint**: After T003–T005, each user story phase can proceed in any order subject to the dependencies noted below.


### PR DESCRIPTION
Implements spec-001 T004 (research.md R8). Closes #14.

## Summary

- Adds a Debug-only shutdown audit that captures the disposal call site of every `IDisposable` owned by `ConnectionManager`, `BootService` and `BLEManager`, so that T006's close/relaunch investigation can correlate "disposed at X" with "reused at Y".
- Release builds are unchanged: the hook's `OnDispose` delegate stays null, so every `Record` call is a cheap null check.

## Design

Two files because Services and `Infrastructure.Protocol.Legacy` cannot reference `GUI.Windows`:

- `Core/Diagnostics/ShutdownAuditHook.cs` — cross-layer static delegate holder with zero deps.
- `GUI.Windows/Diagnostics/ShutdownAudit.cs` — `Enable(ILogger)` wires the hook to a `LogDebug` line that includes `Environment.StackTrace`.

`Program.cs` under ` #if DEBUG`:

- installs the sink before `Application.Run`;
- disposes the `ServiceProvider` in a `finally` block so singleton `IDisposable`s actually run through the audit on shutdown (Release keeps the prior behavior).

Call sites:

- `ConnectionManager.Dispose` + `DisposeActiveServices` — records self + each owned `IProtocolService` / `IBootService` / `ITelemetryService` being disposed.
- `BootService.Dispose` — records self (no owned `IDisposable` fields).
- `BLEManager` — now implements `IDisposable` with a minimal `Dispose` that only records. Actual cleanup of `Plugin.BLE` adapter event subscriptions and connected-device handles is deferred to T007 (US1 root-cause fix) so this PR stays diagnostic-only.

## Test plan

- [x] `dotnet build Stem.Device.Manager.slnx -c Debug` — clean.
- [x] `dotnet build Stem.Device.Manager.slnx -c Release` — clean (validates ` #if DEBUG` branches compile on Release).
- [x] `dotnet test Tests/Tests.csproj --framework net10.0` — 305/305 passing.
- [x] `dotnet test Tests/Tests.csproj --framework net10.0-windows10.0.19041.0` — 483/483 passing.
- [x] Manual: T006 will exercise the audit across 10 close/relaunch cycles on SPARK-UC 2225998 and use the captured stack traces to identify the disposed-object reuse.

## Follow-ups

- T006 uses this audit; T007 applies the fix identified by T006.
- The bench run for T006 is tracked by issue #16.