### PR TITLE
refactor(us2): propagate BlePort disconnect to ConnectionManager (T010, fix #50)

### DIFF
--- a/Infrastructure.Protocol/Hardware/BlePort.cs
+++ b/Infrastructure.Protocol/Hardware/BlePort.cs
@@ -116,6 +116,13 @@ public sealed class BlePort : ICommunicationPort
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Does not call <see cref="IBleDriver.DisconnectAsync"/>: Plugin.BLE
+    /// teardown is owned by the driver's own <c>Dispose</c> (see
+    /// <c>BLEManager.Dispose</c>), invoked later in the DI LIFO order.
+    /// Dispatching a fire-and-forget DisconnectAsync here used to race with
+    /// the driver Dispose on app shutdown (spec-001 issue #50 / H-A).
+    /// </remarks>
     public void Dispose()
     {
         if (_disposed) return;
@@ -123,11 +130,7 @@ public sealed class BlePort : ICommunicationPort
         _driver.PacketReceived -= OnDriverPacketReceived;
         _driver.ConnectionStatusChanged -= OnDriverConnectionChanged;
         if (State != ConnectionState.Disconnected)
-        {
-            try { _ = _driver.DisconnectAsync(); }
-            catch { /* best effort */ }
             Transition(ConnectionState.Disconnected);
-        }
     }
 
     private void OnDriverPacketReceived(object? sender, BlePacketEventArgs e)

--- a/Services/Cache/ConnectionManager.cs
+++ b/Services/Cache/ConnectionManager.cs
@@ -398,6 +398,24 @@ public sealed class ConnectionManager : IDisposable
             _logger.LogInformation("Port {Channel} state -> {State}", port.Kind, state);
         }
         StateChanged?.Invoke(this, new ConnectionStateSnapshot(port.Kind, state));
+
+        // spec-001 C3 item 3 — unsolicited port drop on the active channel
+        // must drive the manager to Disconnected (C1 biconditional).
+        if (state != ConnectionState.Disconnected) return;
+        IProtocolService? protocol;
+        IBootService? boot;
+        ITelemetryService? telemetry;
+        lock (_stateLock)
+        {
+            if (_disposed) return;
+            if (port.Kind != _activeChannel) return;
+            if (_state != ConnectionState.Connected) return;
+            protocol = _activeProtocol;
+            boot = _activeBoot;
+            telemetry = _activeTelemetry;
+            TransitionTo(ConnectionState.Disconnected, "PortStateChanged");
+        }
+        DisposeActiveServices(protocol, boot, telemetry);
     }
 
     private void OnActiveProtocolAppLayer(object? sender, AppLayerDecodedEvent evt)

--- a/Tests/Unit/Infrastructure/Protocol/BlePortTests.cs
+++ b/Tests/Unit/Infrastructure/Protocol/BlePortTests.cs
@@ -276,14 +276,19 @@ public class BlePortTests
     }
 
     [Fact]
-    public void Dispose_FromConnected_CallsDriverDisconnect()
+    public void Dispose_FromConnected_DoesNotCallDriverDisconnect()
     {
+        // spec-001 issue #50: Plugin.BLE teardown is owned by BLEManager.Dispose
+        // (the driver). BlePort.Dispose must only unsubscribe and transition
+        // its own state — no fire-and-forget _driver.DisconnectAsync() that
+        // would race with the driver's own Dispose in DI LIFO order.
         var driver = new FakeBleDriver { IsConnected = true };
         var port = new BlePort(driver);
 
         port.Dispose();
 
-        Assert.Equal(1, driver.DisconnectCount);
+        Assert.Equal(0, driver.DisconnectCount);
+        Assert.Equal(ConnectionState.Disconnected, port.State);
     }
 
     [Fact]
@@ -328,7 +333,8 @@ public class BlePortTests
         port.Dispose();
         port.Dispose();
 
-        Assert.Equal(1, driver.DisconnectCount);
+        Assert.Equal(0, driver.DisconnectCount);
+        Assert.Equal(ConnectionState.Disconnected, port.State);
     }
 
     [Fact]

--- a/Tests/Unit/Services/Cache/ConnectionManagerTests.cs
+++ b/Tests/Unit/Services/Cache/ConnectionManagerTests.cs
@@ -263,6 +263,67 @@ public class ConnectionManagerTests
         Assert.Null(fixture.Manager.CurrentTelemetry);
     }
 
+    // --- Port → Manager disconnect propagation (spec-001 T010, C3 item 3) ---
+
+    [Fact]
+    public async Task PortDisconnected_WhileConnected_ManagerTransitionsToDisconnected()
+    {
+        using var fixture = new Fixture();
+        fixture.BleDriver.IsConnected = true;
+        await fixture.Manager.SwitchToAsync(ChannelKind.Ble);
+
+        fixture.BleDriver.RaiseConnectionStatusChanged(false);
+
+        Assert.Equal(ConnectionState.Disconnected, fixture.Manager.State);
+        Assert.Null(fixture.Manager.ActiveProtocol);
+        Assert.Null(fixture.Manager.CurrentBoot);
+        Assert.Null(fixture.Manager.CurrentTelemetry);
+    }
+
+    [Fact]
+    public async Task PortDisconnected_WhileConnected_DisposesActiveProtocol()
+    {
+        using var fixture = new Fixture();
+        fixture.BleDriver.IsConnected = true;
+        await fixture.Manager.SwitchToAsync(ChannelKind.Ble);
+        var protocol = fixture.Manager.ActiveProtocol!;
+
+        fixture.BleDriver.RaiseConnectionStatusChanged(false);
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => protocol.SendCommandAsync(0, new Command("x", "00", "01"), []));
+    }
+
+    [Fact]
+    public async Task PortDisconnected_NonActiveChannel_ManagerStateUnchanged()
+    {
+        using var fixture = new Fixture();
+        fixture.BleDriver.IsConnected = true;
+        await fixture.Manager.SwitchToAsync(ChannelKind.Ble);
+
+        fixture.PcanDriver.RaiseConnectionStatusChanged(true);
+        fixture.PcanDriver.RaiseConnectionStatusChanged(false);
+
+        Assert.Equal(ConnectionState.Connected, fixture.Manager.State);
+        Assert.NotNull(fixture.Manager.ActiveProtocol);
+    }
+
+    [Fact]
+    public async Task PortDisconnected_StillForwardsStateChangedEvent()
+    {
+        using var fixture = new Fixture();
+        fixture.BleDriver.IsConnected = true;
+        await fixture.Manager.SwitchToAsync(ChannelKind.Ble);
+        var captured = new List<ConnectionStateSnapshot>();
+        fixture.Manager.StateChanged += (_, s) => captured.Add(s);
+
+        fixture.BleDriver.RaiseConnectionStatusChanged(false);
+
+        Assert.Single(captured);
+        Assert.Equal(ChannelKind.Ble, captured[0].Channel);
+        Assert.Equal(ConnectionState.Disconnected, captured[0].State);
+    }
+
     // --- StateOf ---
 
     [Fact]


### PR DESCRIPTION
## Summary

Bundles spec-001 T010 (wire `BlePort.StateChanged → TransitionTo(Disconnected)`) with the latent H-A race fix in `BlePort.Dispose` (issue #50). Both touch `BlePort.cs` / the BLE lifecycle path and share tests.

## Changes

**T010 — `ConnectionManager.OnPortStateChanged`**
- When the active-channel port transitions to `Disconnected` while the manager state is `Connected`, snapshot the protocol/boot/telemetry trio under the lock, call the single-site `TransitionTo(Disconnected, "PortStateChanged")`, then dispose the services outside the lock (same pattern as `DisconnectAsync`).
- Non-active channel transitions keep the existing forward-only `StateChanged` behavior.
- Satisfies spec-001 C3 item 3 (unsolicited port drop is a valid state source) and upholds C1 (state-protocol biconditional) after a physical BLE disconnect.

**#50 — `BlePort.Dispose`**
- Remove the `_ = _driver.DisconnectAsync()` fire-and-forget. Plugin.BLE teardown is owned by `BLEManager.Dispose` (added in PR #49), invoked later in DI LIFO order. Port just unsubscribes and transitions its own state.

**Tests**
- `ConnectionManagerTests`: 4 new tests — active-channel drop propagates to manager state; active protocol is disposed; non-active channel state change is ignored for manager state; `StateChanged` still forwards the port snapshot.
- `BlePortTests`: flipped `Dispose_FromConnected_*` and `Dispose_CalledTwice_IsIdempotent` to assert `DisconnectCount == 0`.

## Scope guard

- No Lean / contract-doc edits — those are handled by T023 (#33).
- No `BLEManager` changes — its `Dispose` already does the right thing since PR #49.

## Test plan

- [x] `dotnet build -c Release -p:EnableWindowsTargeting=true` — green
- [x] `dotnet test --framework net10.0` — 305 passed
- [x] `dotnet test --framework net10.0-windows10.0.19041.0` — 493 passed
- [x] Bench verification of US2 scenario (physical BLE power-off → UI state within 5 s) — covered separately by T012 (#22)

Closes #20
Closes #50