### PR TITLE
fix(us2): route BLE tab device select through SwitchToAsync (#55)

### DIFF
--- a/GUI.Windows/Forms/Form1.cs
+++ b/GUI.Windows/Forms/Form1.cs
@@ -140,7 +140,7 @@ namespace StemPC
             //crea e aggiungi il ble manager. Il tab riceve la stessa istanza BLEManager
             //registrata in DI come IBleDriver del BlePort: scan+connect sul tab → BlePort
             //vede ConnectionStatusChanged → port Connected → SendAsync funziona.
-            BLETabRef = new BLEInterfaceTab(_bleManager);
+            BLETabRef = new BLEInterfaceTab(_bleManager, _connMgr);
             tabControl.TabPages.Add(BLETabRef);
 
             // Sottoscrivi log driver BLE al terminale UI + errori driver BLE/Serial al MessageBox.

--- a/GUI.Windows/Tabs/BLE_WF_Tab.cs
+++ b/GUI.Windows/Tabs/BLE_WF_Tab.cs
@@ -1,7 +1,9 @@
-﻿using GUI.Windows;
+﻿using Core.Models;
+using GUI.Windows;
 
 using GUI.Windows.Properties;
 using Infrastructure.Protocol.Legacy;
+using Services.Cache;
 
 public partial class BLEInterfaceTab : TabPage
 {
@@ -17,10 +19,17 @@ public partial class BLEInterfaceTab : TabPage
     // non vede il ConnectionStatusChanged emesso dopo connect e SendAsync fallisce.
     public BLEManager bleManager;
 
-    public BLEInterfaceTab(BLEManager bleManager)
+    // Needed so the BLE device-select flow routes through SwitchToAsync — the single
+    // C3 source into ConnectionState.Connected. Without this the manager stays at
+    // Disconnected / ActiveProtocol=null after a reconnect post-drop (spec-001 #55).
+    private readonly ConnectionManager _connMgr;
+
+    public BLEInterfaceTab(BLEManager bleManager, ConnectionManager connMgr)
     {
         ArgumentNullException.ThrowIfNull(bleManager);
+        ArgumentNullException.ThrowIfNull(connMgr);
         this.bleManager = bleManager;
+        _connMgr = connMgr;
         InitializeComponent();
     }
 
@@ -131,7 +140,26 @@ public partial class BLEInterfaceTab : TabPage
 
             // Passa il parametro al metodo di connessione
             if (deviceName != null)
+            {
                 await bleManager.ConnectToAsync(deviceName, withResponse);
+
+                // After the driver is connected, route through SwitchToAsync so the
+                // ConnectionManager rebuilds ActiveProtocol/CurrentBoot/CurrentTelemetry.
+                // Covers the reconnect-after-drop case where the port goes Disconnected →
+                // Connected via the BLE tab, not SwitchToAsync (spec-001 #55).
+                try
+                {
+                    await _connMgr.SwitchToAsync(ChannelKind.Ble);
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(
+                        $"Switch canale fallito: {ex.Message}",
+                        "Errore",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                }
+            }
         }
     }
 }

--- a/Tests/Unit/Services/Cache/ConnectionManagerTests.cs
+++ b/Tests/Unit/Services/Cache/ConnectionManagerTests.cs
@@ -309,6 +309,40 @@ public class ConnectionManagerTests
     }
 
     [Fact]
+    public async Task SwitchToAsync_AfterPortDropAndReconnect_RebuildsActiveProtocol()
+    {
+        // spec-001 #55: BLE device re-selection after a drop must rebuild the
+        // protocol/boot/telemetry trio. The tab calls SwitchToAsync(Ble) after
+        // the driver reconnects; the manager should produce a fresh trio even
+        // though the port is already Connected.
+        using var fixture = new Fixture();
+        fixture.BleDriver.IsConnected = true;
+        await fixture.Manager.SwitchToAsync(ChannelKind.Ble);
+        var firstProtocol = fixture.Manager.ActiveProtocol!;
+        var firstBoot = fixture.Manager.CurrentBoot!;
+        var firstTelemetry = fixture.Manager.CurrentTelemetry!;
+
+        // Drop: T010 pulls the manager back to Disconnected + null trio.
+        fixture.BleDriver.RaiseConnectionStatusChanged(false);
+        Assert.Equal(ConnectionState.Disconnected, fixture.Manager.State);
+        Assert.Null(fixture.Manager.ActiveProtocol);
+
+        // Reconnect: driver + port back to Connected (would be the tab's
+        // ConnectToAsync path in prod).
+        fixture.BleDriver.IsConnected = true;
+        fixture.BleDriver.RaiseConnectionStatusChanged(true);
+        await fixture.Manager.SwitchToAsync(ChannelKind.Ble);
+
+        Assert.Equal(ConnectionState.Connected, fixture.Manager.State);
+        Assert.NotNull(fixture.Manager.ActiveProtocol);
+        Assert.NotNull(fixture.Manager.CurrentBoot);
+        Assert.NotNull(fixture.Manager.CurrentTelemetry);
+        Assert.NotSame(firstProtocol, fixture.Manager.ActiveProtocol);
+        Assert.NotSame(firstBoot, fixture.Manager.CurrentBoot);
+        Assert.NotSame(firstTelemetry, fixture.Manager.CurrentTelemetry);
+    }
+
+    [Fact]
     public async Task PortDisconnected_StillForwardsStateChangedEvent()
     {
         using var fixture = new Fixture();


### PR DESCRIPTION
## Summary

`BLE_WF_Tab.listBoxDevices_SelectedIndexChanged` previously went straight to `bleManager.ConnectToAsync(...)`, bypassing `ConnectionManager.SwitchToAsync`. After T010 (PR #54) enforced the C1 biconditional, the manager correctly drops `ActiveProtocol` to null on port disconnect — but the tab's reconnect path had no matching C3 source to rebuild it. Result: after a drop, picking a new BLE device left `ActiveProtocol == null` and Send tripped the ``Select communication channel first!`` guard at `Form1.cs:478`.

Bench trace (from issue #55) confirms the symptom and the shape of the fix.

## Changes

- `GUI.Windows/Tabs/BLE_WF_Tab.cs` — ctor now takes `ConnectionManager`. After the awaited `bleManager.ConnectToAsync(deviceName, withResponse)`, the tab calls `_connMgr.SwitchToAsync(ChannelKind.Ble)` inside a try/catch that mirrors `Form1.SwitchChannelAsync`. Keeps `SwitchToAsync` as the single C3 source 1 into `Connected` — no new C3 sources, no duplicate state-mutation sites.
- `GUI.Windows/Forms/Form1.cs` — one-line update to pass `_connMgr` into the `BLEInterfaceTab` ctor.
- `Tests/Unit/Services/Cache/ConnectionManagerTests.cs` — new test `SwitchToAsync_AfterPortDropAndReconnect_RebuildsActiveProtocol` that walks the full drop → driver-reconnect → `SwitchToAsync(Ble)` cycle and asserts the trio is non-null and freshly allocated (different instances from pre-drop).

## Scope guard

- No contract edits (C3 still lists 4 sources; the tab path resolves to source 1).
- No `ConnectionManager` / `BlePort` / `BLEManager` changes.
- No Lean-spec touches.

## Test plan

- [x] `dotnet build -c Release -p:EnableWindowsTargeting=true` — 0 warnings / 0 errors
- [x] `dotnet test --framework net10.0` — 305 passed
- [x] `dotnet test --framework net10.0-windows10.0.19041.0` — 494 passed (+1 regression test)
- [x] Bench: repeat the #55 reproduction (connect SPARK → disconnect → connect EDENcb → send) and confirm Send succeeds without the channel-first warning.

Closes #55