### PR TITLE
feat(spec-001): T016 FR-010 reject empty firmware up-front

### DIFF
--- a/Services/Boot/SparkBatchUpdateService.cs
+++ b/Services/Boot/SparkBatchUpdateService.cs
@@ -94,6 +94,20 @@ public sealed class SparkBatchUpdateService
         ArgumentNullException.ThrowIfNull(items);
         if (items.Count == 0) return;
 
+        foreach (var item in items)
+        {
+            if (item.Firmware.Length == 0)
+            {
+                var emptyDef = SparkAreas.Get(item.Area);
+                _logger.LogError(
+                    "SPARK batch rejected: empty firmware for area {Area}",
+                    emptyDef.DisplayName);
+                throw new ArgumentException(
+                    $"Empty firmware for area '{emptyDef.DisplayName}'.",
+                    nameof(items));
+            }
+        }
+
         var ordered = items
             .Select(i => (Item: i, Def: SparkAreas.Get(i.Area)))
             .OrderBy(x => x.Def.Order)


### PR DESCRIPTION
US4 sequential gate — first task of the canonical-batch / fault-injected closeout.

Per `specs/001-spark-ble-fw-stabilize/tasks.md` T016: before any on-device side effect, validate that every `SparkBatchItem.Firmware` is non-empty; reject the batch with an `ArgumentException` naming the offending area and one `LogError` line.

## Change

`Services/Boot/SparkBatchUpdateService.ExecuteAsync`: after the null / empty-list guards and before ordering/logging "SPARK batch start", iterate items and throw on the first `Firmware.Length == 0`. Message uses `SparkAreas.Get(item.Area).DisplayName` so the UI can surface which area is missing its payload.

## Why up-front

- FR-010 calls for rejecting the batch before any protocol traffic.
- Failing inside the per-area loop would already have started the bootloader on prior areas — wrong blast radius.

## Follow-ups (separate PRs, parallelizable)

- T017 (#27) — two new `[Fact]`s in `SparkBatchUpdateServiceTests.cs` covering (a) second-area failure aborts and names the area and (b) empty firmware at start throws before any device call.
- T018 (#28) — integration test `Us4_CanonicalBatch_And_FaultInjected_Abort` on `net10.0-windows` for SC-006 / SC-007.

## Test plan

- [x] `dotnet build Stem.Device.Manager.slnx -c Release -p:EnableWindowsTargeting=true` — 0 warnings, 0 errors
- [x] `dotnet test Tests/Tests.csproj --framework net10.0 -c Release` — 307/307 passed
- [x] `dotnet test Tests/Tests.csproj -c Release -p:EnableWindowsTargeting=true` — net10.0 307/307 + net10.0-windows 497/497

Closes #26