### PR TITLE
test(spec-001): T017 US4 batch unit tests for abort-and-name + empty-firmware precondition

### DIFF
--- a/Tests/Unit/Services/Boot/SparkBatchUpdateServiceTests.cs
+++ b/Tests/Unit/Services/Boot/SparkBatchUpdateServiceTests.cs
@@ -146,6 +146,72 @@ public class SparkBatchUpdateServiceTests
     }
 
     [Fact]
+    public async Task Execute_SecondAreaFailsAfterRetries_AbortsAndNamesArea()
+    {
+        // Three areas with DISTINCT recipient ids, in canonical order:
+        // Motor1 (Order=3) → Motor2 (Order=4) → Rostrum (Order=5).
+        // The fake is configured to fail UploadBlocks for the SECOND area
+        // (Motor2), so the first must complete fully and the third must never
+        // be StartBoot-ed.
+        var fake = new FakeBootService
+        {
+            UploadBlocksFailsForRecipient = SparkAreas.Get(SparkFirmwareArea.Motor2).RecipientId,
+        };
+        var orchestrator = new SparkBatchUpdateService(fake);
+        var items = new List<SparkBatchItem>
+        {
+            new(SparkFirmwareArea.Motor1, Fw),
+            new(SparkFirmwareArea.Motor2, Fw),
+            new(SparkFirmwareArea.Rostrum, Fw),
+        };
+
+        var ex = await Assert.ThrowsAsync<SparkBatchUpdateException>(
+            () => orchestrator.ExecuteAsync(items));
+
+        Assert.Equal(SparkFirmwareArea.Motor2, ex.Area.Area);
+        Assert.Equal(SparkBatchPhase.UploadBlocks, ex.Phase);
+
+        // Third area (Rostrum) must never have been StartBoot-ed.
+        var rostrumRecipient = SparkAreas.Get(SparkFirmwareArea.Rostrum).RecipientId;
+        Assert.DoesNotContain(
+            fake.Calls,
+            c => c.Kind == FakeBootCallKind.StartBoot && c.Recipient == rostrumRecipient);
+
+        // First area (Motor1) must have all four call kinds observed.
+        var motor1Recipient = SparkAreas.Get(SparkFirmwareArea.Motor1).RecipientId;
+        var motor1Kinds = fake.Calls
+            .Where(c => c.Recipient == motor1Recipient)
+            .Select(c => c.Kind)
+            .ToList();
+        Assert.Contains(FakeBootCallKind.StartBoot,        motor1Kinds);
+        Assert.Contains(FakeBootCallKind.UploadBlocksOnly, motor1Kinds);
+        Assert.Contains(FakeBootCallKind.EndBoot,          motor1Kinds);
+        Assert.Contains(FakeBootCallKind.Restart,          motor1Kinds);
+    }
+
+    [Fact]
+    public async Task Execute_EmptyFirmwareAtStart_ThrowsBeforeAnyDeviceCall()
+    {
+        // First item has zero-length firmware → precondition must reject
+        // BEFORE any device call, regardless of the rest of the batch.
+        var fake = new FakeBootService();
+        var orchestrator = new SparkBatchUpdateService(fake);
+        var offendingArea = SparkFirmwareArea.Motor1;
+        var items = new List<SparkBatchItem>
+        {
+            new(offendingArea,               Array.Empty<byte>()),
+            new(SparkFirmwareArea.Motor2,    Fw),
+            new(SparkFirmwareArea.Rostrum,   Fw),
+        };
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => orchestrator.ExecuteAsync(items));
+
+        Assert.Empty(fake.Calls);
+        Assert.Contains(SparkAreas.Get(offendingArea).DisplayName, ex.Message);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_RaisesAreaStartedAndCompletedEvents()
     {
         var fake = new FakeBootService();


### PR DESCRIPTION
## Summary

Two new `[Fact]`s in `Tests/Unit/Services/Boot/SparkBatchUpdateServiceTests.cs`:

- `Execute_SecondAreaFailsAfterRetries_AbortsAndNamesArea` — 3-area batch (Motor1, Motor2, Rostrum; distinct recipients). Fake fails UploadBlocks on the second area. Asserts `SparkBatchUpdateException` with `Area.Area == Motor2` and `Phase == UploadBlocks`; third area never `StartBoot`-ed; first area shows all four call kinds.
- `Execute_EmptyFirmwareAtStart_ThrowsBeforeAnyDeviceCall` — first item has `byte[0]` firmware. Asserts `ArgumentException` with the offending area's `DisplayName` in the message, and `fake.Calls` is empty.

No production change. Depends on the T016 precondition merged in #60.

Closes #27

## Test plan

- [x] `dotnet build Stem.Device.Manager.slnx -c Release -p:EnableWindowsTargeting=true` - green
- [x] `dotnet test Tests/Tests.csproj --framework net10.0 --no-build -c Release --filter "FullyQualifiedName~SparkBatchUpdateServiceTests"` - 11/11
- [x] `dotnet test Tests/Tests.csproj --framework net10.0 --no-build -c Release` - 309/309