### PR TITLE
fix: FallbackDictionaryProvider falls back to Excel on HttpClient timeout

### DIFF
--- a/Infrastructure.Persistence/FallbackDictionaryProvider.cs
+++ b/Infrastructure.Persistence/FallbackDictionaryProvider.cs
@@ -43,6 +43,13 @@ public class FallbackDictionaryProvider : IDictionaryProvider
             LastFallbackReason = ex.Message;          // TEMP
             return await _fallback.LoadProtocolDataAsync(ct);
         }
+        catch (OperationCanceledException ex) when (!ct.IsCancellationRequested)
+        {
+            // HttpClient timeout surfaces as TaskCanceledException: fall back to Excel.
+            LastUsedSource = ProviderSource.Fallback; // TEMP
+            LastFallbackReason = ex.Message;          // TEMP
+            return await _fallback.LoadProtocolDataAsync(ct);
+        }
     }
 
     public async Task<IReadOnlyList<Variable>> LoadVariablesAsync(
@@ -57,6 +64,13 @@ public class FallbackDictionaryProvider : IDictionaryProvider
         catch (HttpRequestException)
         {
             LastUsedSource = ProviderSource.Fallback; // TEMP
+            return await _fallback.LoadVariablesAsync(recipientId, ct);
+        }
+        catch (OperationCanceledException ex) when (!ct.IsCancellationRequested)
+        {
+            // HttpClient timeout surfaces as TaskCanceledException: fall back to Excel.
+            LastUsedSource = ProviderSource.Fallback; // TEMP
+            LastFallbackReason = ex.Message;          // TEMP
             return await _fallback.LoadVariablesAsync(recipientId, ct);
         }
     }

--- a/Tests/Unit/Infrastructure/FallbackDictionaryProviderTests.cs
+++ b/Tests/Unit/Infrastructure/FallbackDictionaryProviderTests.cs
@@ -125,6 +125,73 @@ public class FallbackDictionaryProviderTests
             () => provider.LoadProtocolDataAsync(cts.Token));
     }
 
+    // --- Timeout (TaskCanceledException) ---
+
+    [Fact]
+    public async Task LoadProtocolDataAsync_PrimaryTimesOut_ReturnsFallbackData()
+    {
+        var fallbackData = new DictionaryData([], []);
+        var primary = new FailingProvider(
+            new TaskCanceledException("The request was canceled due to the configured HttpClient.Timeout of 30 seconds elapsing."));
+        var fallback = new FakeProvider(fallbackData, []);
+
+        var provider = new global::Infrastructure.Persistence.FallbackDictionaryProvider(
+            primary, fallback);
+
+        var result = await provider.LoadProtocolDataAsync();
+
+        Assert.Same(fallbackData, result);
+        Assert.Contains("HttpClient.Timeout", provider.LastFallbackReason);
+    }
+
+    [Fact]
+    public async Task LoadVariablesAsync_PrimaryTimesOut_ReturnsFallbackVars()
+    {
+        IReadOnlyList<Variable> fallbackVars =
+            [new Variable("Fallback", "0", "0", "Bool")];
+        var primary = new FailingProvider(
+            new TaskCanceledException("The request was canceled due to the configured HttpClient.Timeout of 30 seconds elapsing."));
+        var fallback = new FakeProvider(SampleData, fallbackVars);
+
+        var provider = new global::Infrastructure.Persistence.FallbackDictionaryProvider(
+            primary, fallback);
+
+        var result = await provider.LoadVariablesAsync(0x00080381);
+
+        Assert.Same(fallbackVars, result);
+        Assert.Contains("HttpClient.Timeout", provider.LastFallbackReason);
+    }
+
+    [Fact]
+    public async Task LoadProtocolDataAsync_UserCancelsToken_PropagatesOperationCanceled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var primary = new FailingProvider(new TaskCanceledException("cancelled"));
+        var fallback = new FakeProvider(SampleData, SampleVars);
+
+        var provider = new global::Infrastructure.Persistence.FallbackDictionaryProvider(
+            primary, fallback);
+
+        await Assert.ThrowsAsync<TaskCanceledException>(
+            () => provider.LoadProtocolDataAsync(cts.Token));
+    }
+
+    [Fact]
+    public async Task LoadVariablesAsync_UserCancelsToken_PropagatesOperationCanceled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var primary = new FailingProvider(new TaskCanceledException("cancelled"));
+        var fallback = new FakeProvider(SampleData, SampleVars);
+
+        var provider = new global::Infrastructure.Persistence.FallbackDictionaryProvider(
+            primary, fallback);
+
+        await Assert.ThrowsAsync<TaskCanceledException>(
+            () => provider.LoadVariablesAsync(0x00080381, cts.Token));
+    }
+
     // --- Constructor ---
 
     [Fact]


### PR DESCRIPTION
## Summary
- `HttpClient` timeouts surface as `TaskCanceledException`, which the existing `catch (HttpRequestException)` did not cover — so Azure cold starts escaped to callers instead of falling back to Excel.
- Add `catch (OperationCanceledException) when (!ct.IsCancellationRequested)` on both `LoadProtocolDataAsync` and `LoadVariablesAsync`; genuine user cancellation still propagates. Timeout message recorded in `LastFallbackReason`.

## Test plan
- [x] `dotnet build Stem.Device.Manager.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Tests/Tests.csproj` — net10.0: 504 passed / net10.0-windows: 313 passed
- [x] New tests: timeout -> fallback (both methods), user-cancel -> propagates (both methods)
- [x] Regression: existing `HttpRequestException` -> fallback tests still pass

Closes #47