### PR TITLE
fix: skip dispose-recreate when switching to already-active channel

### DIFF
--- a/Services/Cache/ConnectionManager.cs
+++ b/Services/Cache/ConnectionManager.cs
@@ -166,6 +166,7 @@ public sealed class ConnectionManager : IDisposable
     /// <summary>
     /// Switch to the given channel:
     /// <list type="number">
+    /// <item><description>No-op early return when <paramref name="target"/> is already the <see cref="ActiveChannel"/> and <see cref="ActiveProtocol"/> is live (spec-001 C1: <c>ActiveProtocol != null ⇔ State == Connected</c>).</description></item>
     /// <item><description>Transition to <see cref="ConnectionState.Connecting"/> and dispose the previous <see cref="ActiveProtocol"/> (if any).</description></item>
     /// <item><description><see cref="ICommunicationPort.DisconnectAsync"/> on the previous port (if different from the new one).</description></item>
     /// <item><description><see cref="ICommunicationPort.ConnectAsync"/> on the new port.</description></item>
@@ -190,6 +191,16 @@ public sealed class ConnectionManager : IDisposable
         bool wasConnected;
         lock (_stateLock)
         {
+            // issue #51: clicking the already-active channel menu item must be
+            // a no-op. Guard precedes any TransitionTo so no Connecting log and
+            // no ShutdownAudit dispose record are emitted. Check is inside the
+            // lock to serialize against concurrent SwitchToAsync / port drops;
+            // ActiveProtocol is not null is the C1 biconditional phrasing of
+            // State == Connected, so a dropped-but-still-on-Ble state still
+            // rebuilds the trio (covered by SwitchToAsync_AfterPortDrop test).
+            if (target == _activeChannel && _activeProtocol is not null)
+                return;
+
             oldProtocol = _activeProtocol;
             oldBoot = _activeBoot;
             oldTelemetry = _activeTelemetry;

--- a/Tests/Unit/Services/Cache/ConnectionManagerTests.cs
+++ b/Tests/Unit/Services/Cache/ConnectionManagerTests.cs
@@ -171,6 +171,30 @@ public class ConnectionManagerTests
     }
 
     [Fact]
+    public async Task SwitchToAsync_AlreadyActiveAndConnected_IsNoOp()
+    {
+        // issue #51: clicking the currently-active channel menu item while the
+        // protocol trio is live must be a no-op. Must NOT dispose/recreate the
+        // services (ShutdownAudit records) nor raise ActiveChannelChanged.
+        using var fixture = new Fixture();
+        fixture.BleDriver.IsConnected = true;
+        await fixture.Manager.SwitchToAsync(ChannelKind.Ble);
+        var protocolBefore = fixture.Manager.ActiveProtocol!;
+        var bootBefore = fixture.Manager.CurrentBoot!;
+        var telemetryBefore = fixture.Manager.CurrentTelemetry!;
+        var channelChangedCount = 0;
+        fixture.Manager.ActiveChannelChanged += (_, _) => channelChangedCount++;
+
+        await fixture.Manager.SwitchToAsync(ChannelKind.Ble);
+
+        Assert.Same(protocolBefore, fixture.Manager.ActiveProtocol);
+        Assert.Same(bootBefore, fixture.Manager.CurrentBoot);
+        Assert.Same(telemetryBefore, fixture.Manager.CurrentTelemetry);
+        Assert.Equal(ConnectionState.Connected, fixture.Manager.State);
+        Assert.Equal(0, channelChangedCount);
+    }
+
+    [Fact]
     public async Task SwitchToAsync_InvalidChannel_Throws()
     {
         using var fixture = new Fixture();


### PR DESCRIPTION
## Summary

- `ConnectionManager.SwitchToAsync` early-returns when `target == ActiveChannel` and `ActiveProtocol is not null` (spec-001 C1 biconditional phrasing).
- Guard sits inside `_stateLock`, before the Connecting `TransitionTo`, so no state log and no `ShutdownAudit` records leak in the no-op case.
- Port-drop re-selection path is unaffected: after a drop `ActiveProtocol` is null, so the guard does not fire and the rebuild path (covered by `SwitchToAsync_AfterPortDropAndReconnect_RebuildsActiveProtocol`) still runs.

## Test plan

- [x] `dotnet build Stem.Device.Manager.slnx` clean (0 warnings)
- [x] `dotnet test Tests/Tests.csproj` green on both TFMs (net10.0: 323 passed, net10.0-windows: 515 passed)
- [x] New test `SwitchToAsync_AlreadyActiveAndConnected_IsNoOp` asserts ActiveProtocol/Boot/Telemetry are `Same` after the second call and `ActiveChannelChanged` is not raised
- [x] Existing `SwitchToAsync_FromBleToCan_DisconnectsBleAndConnectsCan` continues to guard the different-channel recreate path
- [x] Existing `SwitchToAsync_AfterPortDropAndReconnect_RebuildsActiveProtocol` continues to guard re-selection after a drop

Closes #51