### PR TITLE
test(spec-001): T015 US3 integration test for HMI upload over full BLE session

### DIFF
--- a/Tests/Integration/Boot/SparkBleStabilizationTests.cs
+++ b/Tests/Integration/Boot/SparkBleStabilizationTests.cs
@@ -1,10 +1,13 @@
+using System.Buffers.Binary;
 using System.Diagnostics;
 using Core.Interfaces;
 using Core.Models;
 using Infrastructure.Protocol.Hardware;
 using Services.Boot;
 using Services.Cache;
+using Services.Protocol;
 using Tests.Unit.Infrastructure.Protocol;
+using Tests.Unit.Services.Protocol;
 
 namespace Tests.Integration.Boot;
 
@@ -137,6 +140,175 @@ public class SparkBleStabilizationTests
             IReadOnlyList<Command> commands,
             IReadOnlyList<Variable> variables,
             IReadOnlyList<ProtocolAddress> addresses) { }
+    }
+
+    // --- US3 single-file upload survives full session -----------------------
+
+    /// <summary>HMI application recipient on SPARK; matches
+    /// <c>SparkAreas.Get(SparkFirmwareArea.HmiApplication).RecipientId</c>.</summary>
+    private const uint HmiRecipient = 0x000702C1u;
+
+    /// <summary>Reply commands the receiving decoder must know about so the
+    /// auto-replier's "80 0X" frames decode into <see cref="AppLayerDecodedEvent"/>
+    /// and unblock <see cref="BootService"/>'s wait-for-reply.</summary>
+    private static readonly Command[] BootReplyCommands =
+    [
+        new("StartProcedureReply", "80", "05"),
+        new("EndProcedureReply",   "80", "06"),
+        new("ProgramBlockReply",   "80", "07"),
+    ];
+
+    /// <summary>
+    /// Spec-001 US3 / SC-003 + SC-005 integration: drives 10 single-file HMI
+    /// uploads through the real <see cref="ConnectionManager"/> +
+    /// <see cref="BlePort"/> + <see cref="BootService"/> chain, with a fake
+    /// <see cref="IBleDriver"/> that auto-replies to every chunked
+    /// <c>StartProcedure</c> / <c>ProgramBlock</c> / <c>EndProcedure</c>. For
+    /// each run the test counts <see cref="ConnectionState.Disconnected"/>
+    /// transitions emitted on the BLE channel during the upload window.
+    ///
+    /// SC-003: every run completes with zero mid-upload disconnect events.
+    /// SC-005: ≥ 95 % upload-success rate. The auto-reply path is deterministic
+    /// so 10/10 = 100 % is the actual measurement; the threshold is asserted
+    /// explicitly so the test fails loud if the codepath ever introduces
+    /// non-determinism (e.g. real bench wiring).
+    ///
+    /// Firmware payload is 50 KB of synthetic bytes — large enough that the
+    /// upload spends sustained time on the BLE port (50 blocks × auto-reply
+    /// round trip) without making the test slow.
+    /// </summary>
+    [Fact]
+    public async Task Us3_Hmi_Upload_SurvivesFullSession()
+    {
+        const int RunCount = 10;
+        const double SuccessRateThreshold = 0.95;
+        var firmware = BuildFirmwareMock(length: 50 * 1024);
+
+        var disconnectsByRun = new int[RunCount];
+        var completedByRun = new bool[RunCount];
+
+        for (int run = 0; run < RunCount; run++)
+        {
+            (disconnectsByRun[run], completedByRun[run]) =
+                await RunOneHmiUpload(firmware);
+        }
+
+        Assert.All(
+            disconnectsByRun,
+            count => Assert.Equal(0, count));
+
+        int successes = completedByRun.Count(c => c);
+        Assert.True(
+            successes >= RunCount * SuccessRateThreshold,
+            $"Upload success rate {successes}/{RunCount} below SC-005 "
+            + $"threshold ({SuccessRateThreshold:P0}).");
+    }
+
+    private static async Task<(int Disconnects, bool Completed)> RunOneHmiUpload(
+        byte[] firmware)
+    {
+        var pcan = new FakePcanDriver();
+        var ble = new FakeBleDriver();
+        var serial = new FakeSerialDriver();
+
+        using var canPort = new CanPort(pcan);
+        using var blePort = new BlePort(ble);
+        using var serialPort = new SerialPort(serial);
+        using var manager = new ConnectionManager(
+            [canPort, blePort, serialPort],
+            new PacketDecoder(BootReplyCommands, [], []),
+            DeviceVariantConfig.Create(DeviceVariant.Egicon));
+
+        ble.IsConnected = true;
+        await manager.SwitchToAsync(ChannelKind.Ble);
+        ble.RaiseConnectionStatusChanged(true);
+        Assert.Equal(ConnectionState.Connected, manager.State);
+
+        ConfigureAutoReply(ble, ownSenderId: DeviceVariantConfig.DefaultSenderId);
+
+        int disconnects = 0;
+        EventHandler<ConnectionStateSnapshot> handler = (_, snap) =>
+        {
+            if (snap.Channel == ChannelKind.Ble
+                && snap.State == ConnectionState.Disconnected)
+                Interlocked.Increment(ref disconnects);
+        };
+        manager.StateChanged += handler;
+
+        var boot = manager.CurrentBoot!;
+        try
+        {
+            await boot.StartFirmwareUploadAsync(firmware, HmiRecipient);
+        }
+        finally
+        {
+            manager.StateChanged -= handler;
+        }
+
+        bool completed = boot.State == BootState.Completed;
+
+        await manager.DisconnectAsync();
+        ble.RaiseConnectionStatusChanged(false);
+        ble.IsConnected = false;
+
+        return (disconnects, completed);
+    }
+
+    private static byte[] BuildFirmwareMock(int length)
+    {
+        var fw = new byte[length];
+        for (int i = 0; i < length; i++) fw[i] = (byte)(i & 0xFF);
+        // fwType bytes 14..15 little-endian — mirrors BootServiceTests pattern.
+        fw[14] = 0x05;
+        fw[15] = 0x00;
+        return fw;
+    }
+
+    /// <summary>
+    /// Hooks <see cref="FakeBleDriver.SendResult"/> so that every chunked
+    /// command's last frame triggers a properly-encoded reply packet
+    /// (<c>CodeHigh = "80"</c>) injected back via
+    /// <see cref="FakeBleDriver.RaisePacketReceived"/>. Mirrors the auto-reply
+    /// pattern in <c>BootServiceTests.Fixture</c>; the difference is that the
+    /// reply is fed into the driver layer instead of the
+    /// <see cref="ICommunicationPort"/> layer, so the full BLE port + protocol
+    /// + boot-service stack is exercised end-to-end.
+    /// </summary>
+    private static void ConfigureAutoReply(FakeBleDriver driver, uint ownSenderId)
+    {
+        var packetTracker = new Dictionary<int, (byte CmdHi, byte CmdLo, uint Recipient)>();
+
+        driver.SendResult = frame =>
+        {
+            var ni = NetInfo.Parse(frame[0], frame[1]);
+            if (ni.SetLength)
+            {
+                uint recipient = BinaryPrimitives.ReadUInt32LittleEndian(
+                    frame.AsSpan(2, 4));
+                packetTracker[ni.PacketId] = (frame[13], frame[14], recipient);
+            }
+            if (ni.RemainingChunks != 0) return true;
+            if (!packetTracker.TryGetValue(ni.PacketId, out var info)) return true;
+            packetTracker.Remove(ni.PacketId);
+
+            // RESTART (00, 0A) is fire-and-forget — no reply on the wire.
+            if (info.CmdLo == 0x0A) return true;
+
+            FireReply(driver, info.Recipient, info.CmdLo, ownSenderId);
+            return true;
+        };
+    }
+
+    private static void FireReply(
+        FakeBleDriver driver, uint originalRecipient, byte cmdLo, uint ownSenderId)
+    {
+        var replyCmd = new Command("Reply", "80", cmdLo.ToString("X2"));
+        using var replyPort = new FakeCommunicationPort(ChannelKind.Ble);
+        var replyDecoder = new PacketDecoder([], [], []);
+        using var replySvc = new ProtocolService(replyPort, replyDecoder, originalRecipient);
+        replySvc.SendCommandAsync(ownSenderId, replyCmd, []).GetAwaiter().GetResult();
+        foreach (var chunk in replyPort.SentPayloads)
+            driver.RaisePacketReceived(chunk, DateTime.UtcNow);
     }
 
     // --- US4 batch orchestration integration test ---------------------------


### PR DESCRIPTION
## Summary

Adds the spec-001 T015 integration test that locks in US3 / SC-003 / SC-005 against regressions in the close-relaunch-or-switch lifecycle: 10 single-file HMI uploads driven end-to-end through `ConnectionManager` + `BlePort` + `BootService` with a fake `IBleDriver` whose `SendResult` auto-replies to every chunked `StartProcedure` / `ProgramBlock` / `EndProcedure`.

## Changes

- `Tests/Integration/Boot/SparkBleStabilizationTests.cs`: new `[Fact] Us3_Hmi_Upload_SurvivesFullSession` (`net10.0-windows`) plus three private helpers — `RunOneHmiUpload`, `ConfigureAutoReply`, `FireReply` — and a 50 KB synthetic firmware builder. Mirrors the auto-reply machinery in `BootServiceTests.Fixture` but feeds replies into the driver layer (`FakeBleDriver.RaisePacketReceived`) instead of `FakeCommunicationPort`, so the full BLE port + protocol + boot-service stack is exercised per run.

## Design notes

- **Upload size.** 50 KB ≈ 50 chunked `ProgramBlock` round trips per run — sustained traffic without making the test slow. Real HMI v8.2 is larger but the assertion is "session survives", not absolute throughput.
- **Disconnect window.** The `StateChanged` listener is wired immediately before `StartFirmwareUploadAsync` and torn down immediately after, so the deliberate `DisconnectAsync` at the end of the run is *not* counted toward SC-003.
- **SC-005 threshold.** Asserted at >= 95 %; the auto-reply path is deterministic so the actual rate is 100 %. Keeping the explicit threshold means a future change that introduces flakiness fails loud instead of silently passing 9/10.
- **Restart sequence.** `BootService.SendRestartSequence` waits the default 1 s between restarts; `RestartCount = 2` means each run spends ~1 s on restart, so the whole `[Fact]` lands at ~10 s. Acceptable for a Windows-only integration test; not a candidate for trimming because shrinking the interval requires the internal `BootService` ctor and the orchestrator inside `ConnectionManager` uses the public one.

Closes #25.

## Review focus

- The `ConfigureAutoReply` / `FireReply` pair: please sanity-check the recipient/sender wiring vs. `BootServiceTests.Fixture.FireReply` — same shape, but the side `FakeCommunicationPort` is being used purely to encode the chunked reply and the chunks are then injected into the driver. If you see a cleaner factoring (e.g. extracting the side encoder into a tiny helper shared with `BootServiceTests`), happy to follow up.

## Testing

- [x] `dotnet build Tests/Tests.csproj -c Debug` — green
- [x] `dotnet test Tests/Tests.csproj --filter "FullyQualifiedName~SparkBleStabilizationTests"` — 4/4 pass on `net10.0-windows`
- [x] `dotnet test Tests/Tests.csproj --framework net10.0` — 327/327 pass (no regressions cross-platform)
- [x] Bench validation against SPARK-UC remains the SC-003/SC-005 ground truth and is tracked separately by the bench runbook in `quickstart.md`.