### PR TITLE
test(spec-001): T021 US5 single-run guard for SC-004 16-min budget

### DIFF
--- a/Tests/Integration/Boot/SparkBleStabilizationTests.cs
+++ b/Tests/Integration/Boot/SparkBleStabilizationTests.cs
@@ -311,6 +311,43 @@ public class SparkBleStabilizationTests
             driver.RaisePacketReceived(chunk, DateTime.UtcNow);
     }
 
+    // --- US5 single-file upload within v2.15 budget -------------------------
+
+    /// <summary>
+    /// Spec-001 US5 / SC-004 / FR-004 regression-guard: a single HMI v8.2
+    /// upload through the real <see cref="ConnectionManager"/> +
+    /// <see cref="BlePort"/> + <see cref="BootService"/> chain, against the
+    /// auto-replying <see cref="FakeBleDriver"/>, completes in ≤ 16 minutes.
+    ///
+    /// With deterministic auto-reply this assertion is trivially true (the
+    /// fake-driven upload completes in seconds — see <see cref="Us3_Hmi_Upload_SurvivesFullSession"/>
+    /// which runs 10 of these in ~10 s). The 16-minute budget exists not as
+    /// a tight bound on this test but as a tripwire against any future
+    /// refactor that introduces an artificial delay (e.g. a stray
+    /// <c>Task.Delay</c>, a runaway retry loop, a sync-over-async deadlock
+    /// resolved by a long timeout) in the boot orchestration. Real-bench
+    /// SC-004 enforcement is the procedure in <c>quickstart.md</c>, run
+    /// against SPARK-UC SN 2225998 with <c>WORKCODE_HMI_RSC.bin</c>.
+    ///
+    /// Five-run mean check (mean ≤ 14 min) is the bench runbook's job per
+    /// tasks.md T021 — tests must be deterministic, so single-run only here.
+    /// </summary>
+    [Fact]
+    public async Task Us5_Hmi_Upload_WithinV215_Budget()
+    {
+        var firmware = BuildFirmwareMock(length: 50 * 1024);
+        var stopwatch = Stopwatch.StartNew();
+
+        await RunOneHmiUpload(firmware);
+
+        stopwatch.Stop();
+
+        Assert.True(
+            stopwatch.Elapsed <= TimeSpan.FromMinutes(16),
+            $"Upload took {stopwatch.Elapsed.TotalMinutes:F2} min, "
+            + "exceeds SC-004 single-run budget of 16 min.");
+    }
+
     // --- US4 batch orchestration integration test ---------------------------
 
     private static readonly byte[] Fw = new byte[16];


### PR DESCRIPTION
## Summary

Adds the spec-001 T021 regression-guard test that locks in US5 / SC-004 / FR-004 against future regressions: a single HMI upload through the real `ConnectionManager` + `BlePort` + `BootService` chain (with the same auto-replying `FakeBleDriver` harness Us3 uses) completes in ≤ 16 minutes.

## Changes

- `Tests/Integration/Boot/SparkBleStabilizationTests.cs`: new `[Fact] Us5_Hmi_Upload_WithinV215_Budget` (`net10.0-windows`). Reuses every helper added by PR #68 — `RunOneHmiUpload`, `ConfigureAutoReply`, `FireReply`, `BuildFirmwareMock`, `BootReplyCommands`, `HmiRecipient` — and wraps the call in a `Stopwatch`. Same 50 KB synthetic firmware as Us3 because the assertion is functional (≤ 16 min), not a benchmark.

## Design notes

- **Why this test exists if it's trivially fast.** With deterministic auto-reply the upload completes in ~1 s. The 16-min budget is a tripwire, not a tight bound — it catches any future refactor that introduces an artificial delay in the boot orchestration (stray `Task.Delay`, runaway retry loop, sync-over-async deadlock resolved by a long timeout). Real-bench SC-004 enforcement is the procedure in [quickstart.md](specs/001-spark-ble-fw-stabilize/quickstart.md), run against SPARK-UC SN 2225998 with `WORKCODE_HMI_RSC.bin`.
- **Why single-run, not five-run mean.** Tasks.md T021 says explicitly: "Five-run mean check is performed by the bench runbook (quickstart.md SC-004), not by the test itself (tests must be deterministic)." A mean would either be a real bench (non-deterministic) or five fake-driven runs that all complete in the same handful of milliseconds — the former breaks CI repeatability, the latter measures nothing.
- **Why this PR follows immediately after PR #69 (T019 perf-regression-scaffold conclusion).** PR #69 documents that the original ~2× regression is no longer reproducing on `main` (3 bench runs in the 13-15 min band on 2026-04-27). T020 (root-cause fix) is skipped because there is nothing to fix. **This PR is the safety net** — if the regression resurfaces, the test catches it before a release ships.

Closes #31.

## Review focus

- The `[Fact]` body is intentionally short — please flag if you'd rather have it inlined (no `RunOneHmiUpload` reuse) for readability vs the current shape that reads as "Us3 minus the multi-run loop, plus a Stopwatch".

## Testing

- [x] `dotnet build Tests/Tests.csproj -c Debug` — green
- [x] `dotnet test Tests/Tests.csproj --filter "FullyQualifiedName~SparkBleStabilizationTests"` — 5/5 pass on `net10.0-windows` (Us1 / Us2 / Us3 / Us4 / Us5)
- [x] `dotnet test Tests/Tests.csproj --framework net10.0` — 327/327 pass (no cross-platform regressions)
- [x] Real-bench SC-004 satisfied as of 2026-04-27 — see PR #69 for the 3-run measurement (13-15 min band)