### PR TITLE
fix(spec-001): SparkBatchUpdateService end-of-batch RESTART_MACHINE only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,7 @@ e Fase 2 (in corso) — services layer + HW adapter + rinomina a pattern Stem.
 
 ### Fixed
 
+- **spec-001 / issue #74 — `SparkBatchUpdateService` end-of-batch restart only.** `RESTART_MACHINE` (CMD `0x000A`) was firing once per area in a multi-area batch, but SPARK firmware shuts the device down on restart, preventing areas 2..N from running. Per STEM firmware-team confirmation (2026-04-27), `RESTART_MACHINE` is hoisted out of `RunAreaAsync` and fires exactly once at the end of the batch, addressed to the HMI board recipient (`0x000702C1`). On the abort path no restart fires — recovery from a half-flashed device is operator-driven. Single-file `IBootService.StartFirmwareUploadAsync` is unchanged. Tests + `Docs/PROTOCOL.md` §8 + `specs/001-spark-ble-fw-stabilize/data-model.md` updated to reflect the batch composition.
 - Blocchi `#if BUTTONPANEL` rimossi da `Form1.cs` (righe ~156, ~344)
 - Blocchi `#if BUTTONPANEL` rimossi da `SplashScreen.cs` (riga ~12)
 - ExcelHandler decoupled da Form1: nessun più chiamate dirette a `hExcel.EstraiDizionario()`

--- a/Docs/PROTOCOL.md
+++ b/Docs/PROTOCOL.md
@@ -403,6 +403,15 @@ fwType = (ushort)((firmwareData[15] << 8) | firmwareData[14]);
 hard-coded in `SendCANAndWaitForResponseAsync` (il parametro `timeoutMs=600`
 è ignorato).
 
+> **Multi-area batch deviation (SPARK).** The four-step sequence above describes a
+> single-file upload. For a multi-area batch via `Services.Boot.SparkBatchUpdateService`,
+> step 4 (`CMD_RESTART_MACHINE`) is hoisted out of the per-area sequence and fires
+> **once at the end of the whole batch**, addressed to the HMI board recipient
+> (`0x000702C1`). Per-area execution stops at step 3. The SPARK firmware shuts the
+> device down on `RESTART_MACHINE`, so a per-area restart would prevent areas
+> 2..N from running. On the abort path (any area fails), no `RESTART_MACHINE` fires
+> at all — recovery from a half-flashed device is operator-driven. Issue #74.
+
 ---
 
 ## 9. Telemetria veloce (TelemetryManager)

--- a/Services/Boot/SparkBatchUpdateService.cs
+++ b/Services/Boot/SparkBatchUpdateService.cs
@@ -83,10 +83,14 @@ public sealed class SparkBatchUpdateService
     public event EventHandler<SparkAreaDefinition>? AreaCompleted;
 
     /// <summary>
-    /// Run the selected areas in canonical order. Each area runs the full
-    /// bootloader sequence (StartBoot → UploadBlocks → EndBoot → Restart).
-    /// On the first failure, throws <see cref="SparkBatchUpdateException"/>;
-    /// remaining areas are not attempted.
+    /// Run the selected areas in canonical order. Each area runs
+    /// <c>StartBoot → UploadBlocks → EndBoot</c>; <c>RESTART_MACHINE</c> is
+    /// hoisted out of the per-area sequence and fires exactly once at the
+    /// end of the batch, addressed to the HMI board (issue #74). On the
+    /// first area failure, throws <see cref="SparkBatchUpdateException"/>;
+    /// remaining areas are not attempted, and the end-of-batch restart is
+    /// also skipped — the device is in a partially-flashed state and
+    /// rebooting could leave it inconsistent. Recovery is operator-driven.
     /// </summary>
     public async Task ExecuteAsync(
         IReadOnlyList<SparkBatchItem> items, CancellationToken ct = default)
@@ -150,6 +154,13 @@ public sealed class SparkBatchUpdateService
             _boot.ProgressChanged -= OnBootProgress;
         }
 
+        // End-of-batch restart, addressed to the HMI board (issue #74,
+        // STEM firmware-team confirmation 2026-04-27). Only reached when
+        // every area completed without throwing — on the abort path the
+        // SparkBatchUpdateException propagates above and this line never
+        // runs, so a half-flashed device is not auto-rebooted.
+        await RestartAtEndOfBatchAsync(ct).ConfigureAwait(false);
+
         _logger.LogInformation("SPARK batch end: all selected areas completed");
     }
 
@@ -159,7 +170,30 @@ public sealed class SparkBatchUpdateService
         await StartBootAsync(def, ct).ConfigureAwait(false);
         await UploadBlocksAsync(item, def, ct).ConfigureAwait(false);
         await EndBootAsync(def, ct).ConfigureAwait(false);
-        await RestartAsync(def, ct).ConfigureAwait(false);
+    }
+
+    private async Task RestartAtEndOfBatchAsync(CancellationToken ct)
+    {
+        var hmiRecipient = SparkAreas.Get(SparkFirmwareArea.HmiApplication).RecipientId;
+        _logger.LogInformation(
+            "SPARK batch restart: addressing CMD_RESTART_MACHINE to HMI {Recipient:X8}",
+            hmiRecipient);
+        try
+        {
+            await _boot.RestartAsync(hmiRecipient, ct).ConfigureAwait(false);
+        }
+        catch (BootSessionLostException ex)
+        {
+            // I1: session lost on the final restart. Surface it as a Restart-phase
+            // failure addressed to HMI (the recipient we just talked to).
+            throw FailSessionLost(SparkAreas.Get(SparkFirmwareArea.HmiApplication), ex);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw Fail(
+                SparkAreas.Get(SparkFirmwareArea.HmiApplication),
+                SparkBatchPhase.Restart, ex.Message, ex);
+        }
     }
 
     private async Task StartBootAsync(SparkAreaDefinition def, CancellationToken ct)
@@ -208,22 +242,6 @@ public sealed class SparkBatchUpdateService
         catch (BootSessionLostException ex)
         {
             throw FailSessionLost(def, ex);
-        }
-    }
-
-    private async Task RestartAsync(SparkAreaDefinition def, CancellationToken ct)
-    {
-        try
-        {
-            await _boot.RestartAsync(def.RecipientId, ct).ConfigureAwait(false);
-        }
-        catch (BootSessionLostException ex)
-        {
-            throw FailSessionLost(def, ex);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            throw Fail(def, SparkBatchPhase.Restart, ex.Message, ex);
         }
     }
 

--- a/Tests/Integration/Boot/SparkBleStabilizationTests.cs
+++ b/Tests/Integration/Boot/SparkBleStabilizationTests.cs
@@ -369,20 +369,27 @@ public class SparkBleStabilizationTests
     /// three-file batch against a manual fake <see cref="IBootService"/>.
     ///
     /// Two logical halves in one <c>[Fact]</c>:
-    /// SC-006 — 10 nominal batches: every area completes (3 areas × 4 boot
-    /// steps = 12 calls recorded, 3 <c>AreaCompleted</c> events per run).
+    /// SC-006 — 10 nominal batches: every area completes (3 areas × 3 per-area
+    /// boot steps + 1 batch-final <c>RESTART_MACHINE</c> to HMI = 10 calls recorded;
+    /// 3 <c>AreaCompleted</c> events per run). The single restart at the end
+    /// is the issue #74 fix: SPARK firmware shuts down on restart, so a
+    /// per-area restart would prevent areas 2..N from running.
     /// SC-007 — 5 fault-injected batches where the second canonical area
     /// fails at <c>UploadBlocks</c>: orchestrator throws
     /// <see cref="SparkBatchUpdateException"/>, aborts before touching the
-    /// third area, and the first area completes fully. The "corrupted
-    /// WEMOTOR1.corrupt.bin" from the bench runbook maps to the fake
-    /// injecting a failure on Motor1's recipient — bytes stay valid because
-    /// the orchestrator never inspects payload.
+    /// third area, **fires zero <c>RESTART_MACHINE</c> commands** (a half-flashed
+    /// device must not be auto-rebooted), and the first area completes
+    /// fully. The "corrupted WEMOTOR1.corrupt.bin" from the bench runbook
+    /// maps to the fake injecting a failure on Motor1's recipient — bytes
+    /// stay valid because the orchestrator never inspects payload.
     /// </summary>
     [Fact]
     public async Task Us4_CanonicalBatch_And_FaultInjected_Abort()
     {
         // SC-006: 10 nominal batches, all three areas succeed.
+        // 3 areas × 3 per-area calls (StartBoot, UploadBlocksOnly, EndBoot)
+        // + 1 end-of-batch Restart (to HMI) = 10 calls per run (issue #74).
+        var hmiRecipient = SparkAreas.Get(SparkFirmwareArea.HmiApplication).RecipientId;
         for (int run = 0; run < 10; run++)
         {
             var fake = new FakeBootService();
@@ -392,8 +399,14 @@ public class SparkBleStabilizationTests
 
             await orchestrator.ExecuteAsync(MakeBatch());
 
-            Assert.Equal(CanonicalBatch.Length * 4, fake.Calls.Count);
+            Assert.Equal(CanonicalBatch.Length * 3 + 1, fake.Calls.Count);
             Assert.Equal(CanonicalBatch, completed.ToArray());
+
+            // Issue #74: exactly one RESTART_MACHINE, addressed to HMI, last call.
+            var restartCalls = fake.Calls.Where(c => c.Kind == FakeBootCallKind.Restart).ToList();
+            Assert.Single(restartCalls);
+            Assert.Equal(hmiRecipient, restartCalls[0].Recipient);
+            Assert.Equal(FakeBootCallKind.Restart, fake.Calls[^1].Kind);
         }
 
         // SC-007: 5 fault-injected batches, second area fails at UploadBlocks.
@@ -424,6 +437,9 @@ public class SparkBleStabilizationTests
                      && c.Recipient == thirdRecipient);
             // First area completed fully (emitted AreaCompleted).
             Assert.Contains(firstArea, completed);
+            // Issue #74: zero RESTART_MACHINE on the abort path — a half-flashed
+            // device must not be auto-rebooted, recovery is operator-driven.
+            Assert.DoesNotContain(FakeBootCallKind.Restart, fake.Calls.Select(c => c.Kind));
         }
     }
 

--- a/Tests/Unit/Services/Boot/SparkBatchUpdateServiceTests.cs
+++ b/Tests/Unit/Services/Boot/SparkBatchUpdateServiceTests.cs
@@ -50,7 +50,8 @@ public class SparkBatchUpdateServiceTests
 
         await orchestrator.ExecuteAsync(items);
 
-        // Each area = 4 calls: StartBoot, UploadBlocksOnly, EndBoot, Restart.
+        // Each area = 3 calls: StartBoot, UploadBlocksOnly, EndBoot. RESTART_MACHINE
+        // is hoisted to the batch end (issue #74) and not part of the per-area sequence.
         // The "Start" calls (one per area) reveal the order.
         var startedAreas = fake.Calls
             .Where(c => c.Kind == FakeBootCallKind.StartBoot)
@@ -177,7 +178,9 @@ public class SparkBatchUpdateServiceTests
             fake.Calls,
             c => c.Kind == FakeBootCallKind.StartBoot && c.Recipient == rostrumRecipient);
 
-        // First area (Motor1) must have all four call kinds observed.
+        // First area (Motor1) must have the three per-area call kinds observed —
+        // but NOT Restart, since RESTART_MACHINE is hoisted to the batch end
+        // and the abort path skips it entirely (issue #74).
         var motor1Recipient = SparkAreas.Get(SparkFirmwareArea.Motor1).RecipientId;
         var motor1Kinds = fake.Calls
             .Where(c => c.Recipient == motor1Recipient)
@@ -186,7 +189,36 @@ public class SparkBatchUpdateServiceTests
         Assert.Contains(FakeBootCallKind.StartBoot,        motor1Kinds);
         Assert.Contains(FakeBootCallKind.UploadBlocksOnly, motor1Kinds);
         Assert.Contains(FakeBootCallKind.EndBoot,          motor1Kinds);
-        Assert.Contains(FakeBootCallKind.Restart,          motor1Kinds);
+        // Issue #74: on the abort path, no RESTART_MACHINE fires anywhere
+        // — half-flashed devices must not be auto-rebooted.
+        Assert.DoesNotContain(FakeBootCallKind.Restart, fake.Calls.Select(c => c.Kind));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NominalBatch_FiresSingleRestartAtEndAddressedToHmi()
+    {
+        // Issue #74: SPARK firmware requires RESTART_MACHINE only at the end of the
+        // batch, addressed to the HMI board. The orchestrator must hoist the per-area
+        // restart out of RunAreaAsync and emit exactly one CMD_RESTART_MACHINE
+        // (recipient = HMI) after the last area completes.
+        var fake = new FakeBootService();
+        var orchestrator = new SparkBatchUpdateService(fake);
+        var items = new List<SparkBatchItem>
+        {
+            new(SparkFirmwareArea.HmiApplication, Fw),
+            new(SparkFirmwareArea.Motor1,         Fw),
+            new(SparkFirmwareArea.Rostrum,        Fw),
+        };
+        var hmiRecipient = SparkAreas.Get(SparkFirmwareArea.HmiApplication).RecipientId;
+
+        await orchestrator.ExecuteAsync(items);
+
+        var restartCalls = fake.Calls.Where(c => c.Kind == FakeBootCallKind.Restart).ToList();
+        Assert.Single(restartCalls);
+        Assert.Equal(hmiRecipient, restartCalls[0].Recipient);
+
+        // Restart must be the LAST call: no further per-area work after it.
+        Assert.Equal(FakeBootCallKind.Restart, fake.Calls[^1].Kind);
     }
 
     [Fact]

--- a/specs/001-spark-ble-fw-stabilize/data-model.md
+++ b/specs/001-spark-ble-fw-stabilize/data-model.md
@@ -56,9 +56,19 @@ Transitions (all from `InProgress`):
 
 In English: if the batch succeeded, every area was completed; if it failed, the failing area is one of the submitted areas.
 
+> **Issue #74 / SPARK firmware constraint.** In batch context the per-area machine
+> below terminates at `AwaitingEnd → Succeeded` (skipping `Restarting`), and the
+> batch composition has a single terminal `BatchRestart` step that fires
+> `RESTART_MACHINE` once at the end of the whole batch, addressed to the HMI
+> board recipient. On the abort path no restart fires at all. The single-file
+> `IBootService.StartFirmwareUploadAsync` entry point still drives the full
+> per-area machine including `Restarting → Succeeded` — that path is unchanged.
+> The Lean encoding of the batch terminal `Restart` step belongs to T024
+> (`BatchComposition.lean`), not formalised here.
+
 ## Boot Step (per-area state machine)
 
-The per-area machine (existing fields captured from `SparkBatchUpdateService.RunAreaAsync` + `BootService.cs`):
+The per-area machine (single-file path, captured from `IBootService.StartFirmwareUploadAsync` + `BootService.cs` — the batch path `SparkBatchUpdateService.RunAreaAsync` terminates one transition earlier per the issue #74 note above):
 
 ```lean
 inductive BootState


### PR DESCRIPTION
## Summary

Per STEM firmware-team confirmation (2026-04-27): on SPARK, `CMD_RESTART_MACHINE` (`0x000A`) must fire **only at the end of a multi-area batch**, not after each area. The device shuts down on restart, so a per-area restart prevents areas 2..N from running. All comms (including the final restart) are addressed to the HMI board (recipient `0x000702C1`).

This was the bug behind issue #74 — surfaced during the spec-001 bench cycle for PR #68 / issue #25 (US3) and tabled pending firmware-team confirmation.

## Changes

- **`Services/Boot/SparkBatchUpdateService.cs`** — `RunAreaAsync` no longer calls `RestartAsync`. `ExecuteAsync` emits one `CMD_RESTART_MACHINE` after the foreach loop, addressed to `SparkAreas.Get(SparkFirmwareArea.HmiApplication).RecipientId`. The per-area `RestartAsync` helper is removed (its `BootSessionLostException` / `Fail` translation lives in the new `RestartAtEndOfBatchAsync`). On the abort path the `SparkBatchUpdateException` propagates out of the foreach and the end-of-batch restart is **never reached** — half-flashed devices must not be auto-rebooted; recovery is operator-driven.
- **`Tests/Unit/Services/Boot/SparkBatchUpdateServiceTests.cs`** — per-area call comment updated to "3 calls per area"; abort-mid-batch test now asserts `Assert.DoesNotContain(FakeBootCallKind.Restart, ...)`; new `[Fact] ExecuteAsync_NominalBatch_FiresSingleRestartAtEndAddressedToHmi` asserts exactly one Restart call, addressed to HMI, and that it's the last call in the sequence.
- **`Tests/Integration/Boot/SparkBleStabilizationTests.cs`** — `Us4_CanonicalBatch_And_FaultInjected_Abort` updated: nominal half asserts `3N + 1` total calls and Restart-to-HMI as the final call; abort half asserts zero Restart calls anywhere.
- **`Docs/PROTOCOL.md` §8** — one-paragraph callout that the four-step legacy sequence applies to single-file uploads; multi-area batch hoists step 4 to the batch end (with the issue #74 reference).
- **`specs/001-spark-ble-fw-stabilize/data-model.md`** — clarification that the per-area state machine in batch context terminates at `AwaitingEnd → Succeeded` (skipping `Restarting`), and that the batch composition has a terminal `BatchRestart` step. Lean encoding of the batch terminal step is deferred to T024 (`BatchComposition.lean` is currently empty).
- **`CHANGELOG.md`** — Fixed entry under Unreleased.

## What's NOT changed

- **`IBootService` surface** — `RestartAsync(uint recipient, CancellationToken)` is unchanged. Single-file `StartFirmwareUploadAsync` still drives the full per-area sequence including the per-area Restart, because that's the right shape for a single-file upload (where the user *wants* the device to reboot and apply the firmware).
- **`Lean/Spec001/BootStateMachine.lean`** — per-area machine including `Restarting → Succeeded` is still accurate for single-file uploads via `StartFirmwareUploadAsync`.
- **`contracts/boot-service.md`** — `IBootService` contract unchanged; the composition concern is captured in `data-model.md` and `PROTOCOL.md`.

## Why no per-area restart on success

If `Area 1` succeeds and `Area 2` fails at `UploadBlocks`, the device has Area 1 fully flashed but Area 2 in an unknown partial state. Rebooting now would commit Area 2's broken state to whatever-the-firmware-does-on-boot. Better: surface the failure, leave the device powered on but unrebooted, let the operator decide whether to re-attempt or recover. This matches the existing `SparkBatchUpdateException` semantics.

## Real-bench validation

Bench validation of SC-006 (10 nominal canonical batches) and SC-007 (5 fault-injected) **deferred** — first opportunity Luca gets at the SPARK-UC. PR is mergeable without it because:

- All existing US4 tests + the new `ExecuteAsync_NominalBatch_FiresSingleRestartAtEndAddressedToHmi` pass on `net10.0-windows`
- The fix matches the firmware-team's explicit specification
- The previous code path provably could not satisfy SC-006 on real hardware (per-area restart shut the device down before area 2)

Closes #74.

## Review focus

- The decision to skip restart on the abort path. If you'd rather always reboot (even after a failure) so the device returns to a consistent powered-state, flag and I'll change to "fire restart at end always, success or failure". My read: not rebooting a half-flashed device is the safer default, but this is a policy call I'm guessing on.
- Whether `RestartAtEndOfBatchAsync` should also distinguish "session lost during the final restart" from "transient failure during the final restart" the same way the per-area `EndBoot` / `UploadBlocks` paths do. Currently it does: `BootSessionLostException` → `FailSessionLost(HMI def)`, other exceptions → `Fail(HMI def, Restart, ...)`.

## Testing

- [x] `dotnet build Tests/Tests.csproj -c Debug` — green
- [x] `dotnet test Tests/Tests.csproj --filter "...SparkBatchUpdateServiceTests|...SparkBleStabilizationTests"` — 17/17 pass on `net10.0-windows`
- [x] `dotnet test Tests/Tests.csproj --framework net10.0` — 328/328 pass (was 327; +1 for the new fact)
- [x] Real-bench SC-006 + SC-007 validation against SPARK-UC SN 2225998 — deferred to next bench window