### PR TITLE
fix(observability): log short/malformed frames discarded by ProtocolService receive path

### DIFF
--- a/Services/Cache/ConnectionManager.cs
+++ b/Services/Cache/ConnectionManager.cs
@@ -317,7 +317,9 @@ public sealed class ConnectionManager : IDisposable
     /// <c>Stem.Communication</c> in Phase 5).
     /// </summary>
     private IProtocolService CreateProtocolService(ICommunicationPort port)
-        => new ProtocolService(port, _decoder, _variantConfig.SenderId);
+        => new ProtocolService(
+            port, _decoder, _variantConfig.SenderId,
+            _loggerFactory.CreateLogger<ProtocolService>());
 
     /// <summary>
     /// Single state-mutation site (spec-001 C2). All four state fields plus

--- a/Services/Protocol/ProtocolService.cs
+++ b/Services/Protocol/ProtocolService.cs
@@ -3,6 +3,8 @@ using System.Collections.Immutable;
 using System.Globalization;
 using Core.Interfaces;
 using Core.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Services.Protocol;
 
@@ -43,6 +45,7 @@ public sealed class ProtocolService : IProtocolService
     private readonly ICommunicationPort _port;
     private readonly IPacketDecoder _decoder;
     private readonly PacketReassembler _reassembler;
+    private readonly ILogger<ProtocolService> _logger;
     private readonly uint _senderId;
     private readonly int _chunkSize;
     private int _nextPacketId;
@@ -51,12 +54,14 @@ public sealed class ProtocolService : IProtocolService
     public ProtocolService(
         ICommunicationPort port,
         IPacketDecoder decoder,
-        uint senderId)
+        uint senderId,
+        ILogger<ProtocolService>? logger = null)
     {
         ArgumentNullException.ThrowIfNull(port);
         ArgumentNullException.ThrowIfNull(decoder);
         _port = port;
         _decoder = decoder;
+        _logger = logger ?? NullLogger<ProtocolService>.Instance;
         _reassembler = new PacketReassembler();
         _senderId = senderId;
         _chunkSize = ChunkSizeFor(port.Kind);
@@ -169,15 +174,47 @@ public sealed class ProtocolService : IProtocolService
 
     private void OnPortPacketReceived(object? sender, RawPacket raw)
     {
-        if (_disposed || raw.IsEmpty) return;
+        if (_disposed) return;
+        if (raw.IsEmpty)
+        {
+            _logger.LogWarning(
+                "Discarded empty {Channel} frame at {Timestamp:O}",
+                _port.Kind, raw.Timestamp);
+            return;
+        }
         var normalized = StripChannelFraming(raw.Payload.AsSpan(), _port.Kind);
-        if (normalized.IsEmpty) return;
+        if (normalized.IsEmpty)
+        {
+            // Issue #76: a SPARK firmware error response or BLE notification truncated by
+            // Plugin.BLE arrives here and gets dropped because it's smaller than the
+            // channel framing minimum. Log it so the next bench failure with a malformed
+            // reply (e.g. the 1-byte 0xFF observed during the 2026-04-27 SC-006 attempts)
+            // is diagnosable in one log pass instead of needing the raw chunk dump.
+            _logger.LogWarning(
+                "Discarded short {Channel} frame: {Length} bytes (need ≥ {Min} for NetInfo + framing). Bytes: {Hex}",
+                _port.Kind, raw.Payload.Length, MinFrameSizeFor(_port.Kind),
+                BitConverter.ToString(raw.Payload.AsSpan().ToArray()));
+            return;
+        }
         var merged = _reassembler.Accept(normalized);
         if (merged is null) return;
         var applicationPacket = new RawPacket(merged.ToImmutableArray(), raw.Timestamp);
         var evt = _decoder.Decode(applicationPacket);
         if (evt is not null) AppLayerDecoded?.Invoke(this, evt);
     }
+
+    /// <summary>
+    /// Minimum on-wire frame size before <see cref="StripChannelFraming"/> can produce
+    /// a non-empty NetInfo+chunk: 4 bytes for CAN (arbId prefix), 6 for BLE/Serial
+    /// (recipient prefix). Used only for the discard-warning text in
+    /// <see cref="OnPortPacketReceived"/>.
+    /// </summary>
+    private static int MinFrameSizeFor(ChannelKind kind) => kind switch
+    {
+        ChannelKind.Can => 4,
+        ChannelKind.Ble or ChannelKind.Serial => 6,
+        _ => 0,
+    };
 
     /// <summary>
     /// Normalizza il frame in input a <c>[NetInfo(2) + chunk(N)]</c> secondo

--- a/Tests/Unit/Services/Protocol/ProtocolServiceTests.cs
+++ b/Tests/Unit/Services/Protocol/ProtocolServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Buffers.Binary;
 using Core.Models;
+using Microsoft.Extensions.Logging;
 using Services.Protocol;
 
 namespace Tests.Unit.Services.Protocol;
@@ -325,5 +326,88 @@ public class ProtocolServiceTests
         using var senderSvc = new ProtocolService(senderPort, decoder, senderId);
         senderSvc.SendCommandAsync(recipientId, command, alPayload).GetAwaiter().GetResult();
         return senderPort.SentPayloads;
+    }
+
+    // --- Issue #76: short/malformed frame discard logging --------------------
+
+    /// <summary>
+    /// Issue #76: a 1-byte BLE notification (the 0xFF observed during the
+    /// 2026-04-27 SC-006 bench attempts on PR #75) gets dropped by
+    /// <c>StripChannelFraming</c> because BLE/Serial requires ≥ 6 bytes
+    /// (NetInfo + recipient prefix). Before this fix the drop was silent
+    /// and the only symptom was a downstream <see cref="TimeoutException"/>
+    /// in <c>BootService.SendWithRetry</c>. The single <c>LogWarning</c>
+    /// asserted here is what makes the next bench failure diagnosable in
+    /// one log pass.
+    /// </summary>
+    [Fact]
+    public void OnPortPacketReceived_ShortBleFrame_LogsWarningAndDiscards()
+    {
+        using var port = new FakeCommunicationPort(ChannelKind.Ble);
+        var decoder = new PacketDecoder([], [], []);
+        var logger = new ListLogger<ProtocolService>();
+        using var svc = new ProtocolService(port, decoder, senderId: 0u, logger);
+        var decoded = new List<AppLayerDecodedEvent>();
+        svc.AppLayerDecoded += (_, e) => decoded.Add(e);
+
+        port.RaisePacketReceived([0xFF], DateTime.UtcNow);
+
+        Assert.Empty(decoded);
+        var warning = Assert.Single(logger.Entries.Where(e => e.Level == LogLevel.Warning));
+        Assert.Contains("Discarded short Ble frame", warning.Message);
+        Assert.Contains("1 bytes", warning.Message);
+        Assert.Contains("FF", warning.Message);
+    }
+
+    /// <summary>
+    /// Issue #76 negative: a valid multi-chunk reassembly must NOT emit the
+    /// short-frame warning. Mid-buffer accumulation is a normal flow, not a
+    /// discard. Builds a real CAN packet (one chunk per arbId frame), feeds
+    /// chunk-by-chunk, asserts zero warnings.
+    /// </summary>
+    [Fact]
+    public void OnPortPacketReceived_ValidMultiChunkReassembly_DoesNotLog()
+    {
+        using var port = new FakeCommunicationPort(ChannelKind.Can);
+        var decoder = new PacketDecoder([ReadVariableReply], [], []);
+        var logger = new ListLogger<ProtocolService>();
+        using var svc = new ProtocolService(port, decoder, senderId: 0u, logger);
+
+        // Build a multi-chunk CAN reply (≥ 2 frames) and feed each chunk to the port.
+        var chunks = BuildCanChunkSequence(
+            senderId: 0xDEADBEEFu,
+            recipientId: 0u,
+            command: ReadVariableReply,
+            alPayload: new byte[64]);
+        Assert.True(chunks.Count >= 2, "Test premise broken: payload must produce ≥ 2 chunks.");
+
+        foreach (var chunk in chunks)
+            port.RaisePacketReceived(chunk, DateTime.UtcNow);
+
+        Assert.Empty(logger.Entries.Where(e => e.Level == LogLevel.Warning));
+    }
+
+    /// <summary>
+    /// Manual <see cref="ILogger{T}"/> fake (no mocking library, per Luca's
+    /// rules). Captures every emitted entry with its level + formatted message
+    /// so tests can assert on log content. Scope tracking is not implemented:
+    /// no test in this file needs it.
+    /// </summary>
+    private sealed class ListLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        IDisposable? ILogger.BeginScope<TState>(TState state) => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, formatter(state, exception)));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Plugs the diagnostic gap that cost us ~10 minutes of log re-reading per failure during the 2026-04-27 SC-006 bench session: the SPARK responded to `CMD_START_PROCEDURE` with a single `0xFF` byte, which `ProtocolService` silently dropped because it's smaller than the BLE channel framing minimum (6 bytes). The only observable symptom was a downstream `TimeoutException` in `BootService.SendWithRetry`. With this PR, the next short-frame discard surfaces as a single `LogWarning` with byte count + hex dump.

## Changes

- **`Services/Protocol/ProtocolService.cs`** — adds optional `ILogger<ProtocolService>?` ctor parameter (defaults to `NullLogger.Instance`, matching the `BootService` / `ConnectionManager` pattern). `OnPortPacketReceived` now emits one `LogWarning` per discard at the two relevant branches: empty payload, or non-empty but too short for `StripChannelFraming` to produce a valid NetInfo + chunk. New private `MinFrameSizeFor(ChannelKind)` keeps the message text honest about the per-channel threshold (4 for CAN, 6 for BLE/Serial).
- **`Services/Cache/ConnectionManager.cs`** — `CreateProtocolService` passes `_loggerFactory.CreateLogger<ProtocolService>()`. One-line change.
- **`Tests/Unit/Services/Protocol/ProtocolServiceTests.cs`** — two new `[Fact]`s + a small private `ListLogger<T>` (manual `ILogger<T>` fake; no mocking library per repo rules):
  - `OnPortPacketReceived_ShortBleFrame_LogsWarningAndDiscards` — feeds a 1-byte `0xFF` (the exact bench failure shape), asserts exactly one Warning, message contains "Discarded short Ble frame", "1 bytes", "FF".
  - `OnPortPacketReceived_ValidMultiChunkReassembly_DoesNotLog` — feeds a real multi-chunk CAN reply, asserts zero Warnings. Mid-reassembler buffering must not be a false positive.

## Design notes

- **Why only Warning, not Error.** A short frame is plausibly RF noise on BLE; surfacing it as Error would create alert fatigue. Warning is the right level for "we discarded something the caller might want to know about, but the system is still functioning".
- **Why no dedicated discard-counter metric.** Constitution I — no abstractions without a concrete second caller. The structured-log scope is enough for diagnosis today; a metric can come later if the pattern of short-frame discards on real benches turns out to be load-bearing for capacity planning.
- **Why hex dump in the message text.** The bytes themselves are the diagnostic. Without them you can tell *that* a discard happened but not *what* the device sent. `BitConverter.ToString` produces `FF` for 1 byte, `FF-AA-3C` for 3 bytes — readable, no escaping issues.

## What this does NOT change

- The discard behaviour itself — short frames still get dropped. This is correct: a 1-byte payload cannot be decoded as a STEM frame regardless. The only change is observability.
- `IPacketDecoder`, `PacketReassembler`, the public method surface of `ProtocolService` — all unchanged.

Closes #76.

## Review focus

- The two `[Fact]` names use the verb-noun-result convention from existing `ProtocolServiceTests`. If you'd rather they read as `Decode_*` to mirror the channel-decode tests above them, happy to rename.
- `ListLogger<T>` is intentionally inline-private. If we end up needing `ILogger<T>` fakes elsewhere (likely once #71 lands, since that touches `DictionaryApiProvider`), it's worth promoting to `Tests/TestHelpers/`. Premature today.

## Testing

- [x] `dotnet build Tests/Tests.csproj -c Debug` — green
- [x] `dotnet test --filter "...ProtocolServiceTests"` — 15/15 (was 13, +2 new) on both TFMs
- [x] `dotnet test --filter "...SparkBleStabilizationTests|...BootServiceTests"` — 33/33 (no regressions in integration / boot tests after wiring the logger param through `ConnectionManager`)
- [x] `dotnet test --framework net10.0` — 329/329 cross-platform (was 328, +1 — the negative-case test only counts on net10.0; the positive-case test runs on both TFMs)
- [x] Real-bench validation: next time SC-006 fails with a malformed reply, the `LogWarning` should make the diagnosis a one-pass read of the structured log