### PR TITLE
fix: extend DictionaryApiProvider HttpMessageHandler lifetime to 10 min

### DIFF
--- a/Infrastructure.Persistence/DependencyInjection.cs
+++ b/Infrastructure.Persistence/DependencyInjection.cs
@@ -46,7 +46,7 @@ public static class DependencyInjection
                 client.BaseAddress = new Uri(options.BaseUrl.TrimEnd('/') + "/");
                 client.DefaultRequestHeaders.Add("X-Api-Key", options.ApiKey);
                 client.Timeout = TimeSpan.FromSeconds(options.TimeoutSeconds);
-            });
+            }).SetHandlerLifetime(TimeSpan.FromMinutes(10));
 
             services.AddSingleton<IDictionaryProvider>(sp =>
             {


### PR DESCRIPTION
Closes #71.

The default 2-min handler lifetime races with idle bench sessions — when the operator clicks Connect after ~2 min of idle, the in-flight dictionary lookup throws ObjectDisposedException because the underlying handler is mid-rotation.

10 min covers any plausible bench-session idle window without disabling rotation entirely.

## Test plan
- [x] dotnet build green
- [x] dotnet test --framework net10.0 green (DictionaryApiProvider unit tests still pass)
- [x] Bench: launch app, leave idle 5+ min, click Connect → no ODE in log around the connect window