### PR TITLE
feat(spec-001): T022 BootStateMachine preservation theorems T1..T4

### DIFF
--- a/Lean/Spec001/BootStateMachine.lean
+++ b/Lean/Spec001/BootStateMachine.lean
@@ -1,10 +1,16 @@
 import Mathlib
 
 /-!
-# Boot state machine (spec-001, T005)
+# Boot state machine (spec-001, T005 + T022)
 
-Per-area firmware upload state machine. Types and transitions only — the
-preservation theorems T1..T4 are deferred to T022.
+Per-area firmware upload state machine. State, transitions, and the four
+preservation theorems T1..T4:
+
+- T1 (offset-total): every reachable `Uploading off tot _` has `off ≤ tot`.
+- T2 (retry-bounded): every reachable `Uploading _ _ att` has `att ≤ RetryBudget`.
+- T3 (terminal stability): `Succeeded` and `Failed` have no outgoing transitions.
+- T4 (phase-preservation on abort): each `Failed phase _` arrival is reached
+  from the source state corresponding to `phase`.
 
 See `specs/001-spark-ble-fw-stabilize/data-model.md` for the source of truth;
 every transition label in this file corresponds to one bullet in the
@@ -91,5 +97,97 @@ inductive Reaches : BootState → BootState → Prop where
 
 /-- A state is reachable from the initial `Idle`. -/
 def Reachable (s : BootState) : Prop := Reaches .Idle s
+
+/-! ### T022 — preservation theorems (US3 / FR-007) -/
+
+/-- Single inductive invariant carrying T1 (offset-total) and T2 (retry-bounded)
+    for `Uploading` states; trivially `True` everywhere else. -/
+def UploadInvariant : BootState → Prop
+  | .Uploading off tot att => off ≤ tot ∧ att ≤ RetryBudget
+  | _ => True
+
+private theorem invariant_idle : UploadInvariant .Idle := trivial
+
+private theorem invariant_step {s t : BootState}
+    (h_inv : UploadInvariant s) (h_step : Step s t) : UploadInvariant t := by
+  cases h_step with
+  | startBootInvoked => trivial
+  | startBootAcked total =>
+      exact ⟨Nat.zero_le _, by decide⟩
+  | startBootExhausted _ => trivial
+  | chunkAcked off tot att chunk h =>
+      obtain ⟨_, h_att⟩ := h_inv
+      exact ⟨h, h_att⟩
+  | chunkRetry off tot att h =>
+      obtain ⟨h_off, _⟩ := h_inv
+      exact ⟨h_off, h⟩
+  | chunkExhausted _ _ _ => trivial
+  | uploadComplete _ _ => trivial
+  | endBootAcked => trivial
+  | endBootExhausted _ => trivial
+  | restartAcked => trivial
+  | restartExhausted _ => trivial
+
+private theorem invariant_reaches {s t : BootState}
+    (h_reach : Reaches s t) (h_inv : UploadInvariant s) : UploadInvariant t := by
+  induction h_reach with
+  | refl => exact h_inv
+  | step _ h_step ih => exact invariant_step ih h_step
+
+private theorem reachable_invariant {s : BootState}
+    (h : Reachable s) : UploadInvariant s :=
+  invariant_reaches h invariant_idle
+
+/-- **T1 (offset-total).** Every reachable `Uploading` state has its offset
+    bounded by the total firmware length. -/
+theorem reachable_uploading_offset_le_total {off tot att : Nat}
+    (h : Reachable (.Uploading off tot att)) : off ≤ tot :=
+  (reachable_invariant h).1
+
+/-- **T2 (retry-bounded, FR-007).** Every reachable `Uploading` state has its
+    attempt counter bounded by `RetryBudget`. -/
+theorem reachable_uploading_attempt_le_budget {off tot att : Nat}
+    (h : Reachable (.Uploading off tot att)) : att ≤ RetryBudget :=
+  (reachable_invariant h).2
+
+/-- **T3 (terminal stability) — `Succeeded`.** No transition leaves
+    `Succeeded`. Direct case analysis on `Step`: no constructor has
+    `Succeeded` as its source. -/
+theorem succeeded_no_step : ∀ t, ¬ Step .Succeeded t := by
+  intro t h; cases h
+
+/-- **T3 (terminal stability) — `Failed`.** No transition leaves `Failed`. -/
+theorem failed_no_step (phase : BootPhase) (cause : String) :
+    ∀ t, ¬ Step (.Failed phase cause) t := by
+  intro t h; cases h
+
+/-- **T4 (phase-preservation on abort).** A `Failed StartBoot _` is only
+    reached from `AwaitingStart`. -/
+theorem failed_startBoot_source {s : BootState} {cause : String}
+    (h : Step s (.Failed .StartBoot cause)) : s = .AwaitingStart := by
+  cases h
+  rfl
+
+/-- **T4 (phase-preservation on abort).** A `Failed UploadBlocks _` is only
+    reached from `Uploading _ _ RetryBudget` (the post-budget exhaustion). -/
+theorem failed_uploadBlocks_source {s : BootState} {cause : String}
+    (h : Step s (.Failed .UploadBlocks cause)) :
+    ∃ off tot, s = .Uploading off tot RetryBudget := by
+  cases h with
+  | chunkExhausted off tot _ => exact ⟨off, tot, rfl⟩
+
+/-- **T4 (phase-preservation on abort).** A `Failed EndBoot _` is only
+    reached from `AwaitingEnd`. -/
+theorem failed_endBoot_source {s : BootState} {cause : String}
+    (h : Step s (.Failed .EndBoot cause)) : s = .AwaitingEnd := by
+  cases h
+  rfl
+
+/-- **T4 (phase-preservation on abort).** A `Failed Restart _` is only
+    reached from `Restarting`. -/
+theorem failed_restart_source {s : BootState} {cause : String}
+    (h : Step s (.Failed .Restart cause)) : s = .Restarting := by
+  cases h
+  rfl
 
 end Spec001.BootStateMachine


### PR DESCRIPTION
Closes #32.

Adds the four preservation theorems on `Spec001.BootStateMachine`:

- **T1 (offset-total)**: every reachable `Uploading off tot _` has `off ≤ tot`.
- **T2 (retry-bounded, FR-007)**: every reachable `Uploading _ _ att` has `att ≤ RetryBudget`.
- **T3 (terminal stability)**: `Succeeded` and `Failed _ _` have no outgoing `Step`.
- **T4 (phase-preservation on abort)**: each `Failed phase _` arrival comes from the unique source state corresponding to `phase` (\`StartBoot ← AwaitingStart\`, \`UploadBlocks ← Uploading _ _ RetryBudget\`, \`EndBoot ← AwaitingEnd\`, \`Restart ← Restarting\`).

## Approach

T1 and T2 share a single inductive invariant `UploadInvariant : BootState → Prop` that's `True` everywhere except `Uploading`, where it carries the conjunction `off ≤ tot ∧ att ≤ RetryBudget`. Preservation is closed by case-on-`Step`; `Reaches` is closed by induction with the step lemma.

T3 and T4 are single-line case analyses on `Step` — non-matching constructors get pruned automatically by index unification.

## Test plan
- [x] \`lake build\` green (Spec001.BootStateMachine + full project)
- [x] No \`sorry\` / \`admit\` in the file