### PR TITLE
feat(spec-001): T023 BleLifecycle protocol-state biconditional T5

### DIFF
--- a/Lean/Spec001/BleLifecycle.lean
+++ b/Lean/Spec001/BleLifecycle.lean
@@ -1,14 +1,20 @@
 import Mathlib
 
 /-!
-# BLE session lifecycle (spec-001, T005)
+# BLE session lifecycle (spec-001, T005 + T023)
 
-Types and transitions only — the core invariant T5 (protocol-state
-biconditional, `activeProtocol.isSome ↔ state = Connected`) is deferred
-to T023.
+State, transitions, and the core invariant T5 (US2):
+
+> `∀ s, Reachable s → s.2.isSome ↔ s.1 = Connected`
 
 Mirrors `ConnectionManager.ConnectionState` + `ConnectionManager.ActiveProtocol`
-in the C# side. See `specs/001-spark-ble-fw-stabilize/data-model.md`.
+in the C# side, where the C# invariant is `ActiveProtocol = null iff State ≠
+Connected`. See `specs/001-spark-ble-fw-stabilize/data-model.md`.
+
+The transitions that leave `Connected` (user-initiated disconnect, unsolicited
+drop) drop the handle atomically — that atomicity is what makes the
+biconditional hold by construction, and is the structural fix US2 wires up
+on the C# side via `ConnectionManager.TransitionTo`.
 -/
 
 namespace Spec001.BleLifecycle
@@ -48,12 +54,16 @@ inductive Step : AppState → AppState → Prop where
   -- `Connecting → Disconnected` on connect failure.
   | connectFailed :
       Step (.Connecting, none) (.Disconnected, none)
-  -- `Connected → Disconnecting` on user-initiated disconnect.
+  -- `Connected → Disconnecting` on user-initiated disconnect. The handle is
+  -- dropped atomically on leaving `Connected` so the T5 biconditional is
+  -- preserved at every step (the C# `ConnectionManager.TransitionTo` does
+  -- the same — `ActiveProtocol = null iff State ≠ Connected`).
   | userDisconnect (h : ProtocolHandle) :
-      Step (.Connected, some h) (.Disconnecting, some h)
-  -- `Disconnecting → Disconnected` on `DeviceDisconnected` + handle drop.
-  | deviceDisconnected (h : ProtocolHandle) :
-      Step (.Disconnecting, some h) (.Disconnected, none)
+      Step (.Connected, some h) (.Disconnecting, none)
+  -- `Disconnecting → Disconnected` on `DeviceDisconnected`. The handle is
+  -- already `none` from `userDisconnect`.
+  | deviceDisconnected :
+      Step (.Disconnecting, none) (.Disconnected, none)
   -- `Connected → Disconnected` on unsolicited drop (the US2/US3 failure
   -- mode). Handle MUST be dropped atomically — this is what T5 enforces.
   | unsolicitedDrop (h : ProtocolHandle) :
@@ -66,5 +76,35 @@ inductive Reaches : AppState → AppState → Prop where
 
 /-- A state is reachable from the initial `(Disconnected, none)`. -/
 def Reachable (s : AppState) : Prop := Reaches (.Disconnected, none) s
+
+/-! ### T023 — protocol-state biconditional (US2 / SC-002) -/
+
+/-- The biconditional itself, expressed as a predicate on `AppState` so it
+    can be carried by the induction over `Reaches`. -/
+def StateProtocolAgreement (s : AppState) : Prop :=
+  s.2.isSome ↔ s.1 = .Connected
+
+private theorem agreement_initial : StateProtocolAgreement (.Disconnected, none) := by
+  simp [StateProtocolAgreement]
+
+private theorem agreement_step {s t : AppState}
+    (h_inv : StateProtocolAgreement s) (h_step : Step s t) :
+    StateProtocolAgreement t := by
+  cases h_step <;> simp [StateProtocolAgreement]
+
+private theorem agreement_reaches {s t : AppState}
+    (h_reach : Reaches s t) (h_inv : StateProtocolAgreement s) :
+    StateProtocolAgreement t := by
+  induction h_reach with
+  | refl => exact h_inv
+  | step _ h_step ih => exact agreement_step ih h_step
+
+/-- **T5 (protocol-state agreement, US2 / SC-002).** For every reachable
+    `(state, handle)` pair, the handle is present iff the lifecycle stage
+    is `Connected`. This is the structural fact the C# fix for US2 enforces
+    via a single mutator `ConnectionManager.TransitionTo`. -/
+theorem reachable_state_protocol_agreement {s : AppState}
+    (h : Reachable s) : s.2.isSome ↔ s.1 = .Connected :=
+  agreement_reaches h agreement_initial
 
 end Spec001.BleLifecycle


### PR DESCRIPTION
Closes #33.

Proves T5 on `Spec001.BleLifecycle`:

> \`∀ s, Reachable s → s.2.isSome ↔ s.1 = Connected\`

This is the structural fact behind US2 / SC-002 — the UI's "connected" indicator is truthful because the protocol handle slot agrees with the lifecycle stage at every step.

## Skeleton fix

The T005 skeleton modelled \`Disconnecting\` as still carrying the handle (\`(Disconnecting, some h)\`), which makes the biconditional false at that intermediate state. The C# semantics drop \`ActiveProtocol\` on leaving \`Connected\` (the invariant is \`ActiveProtocol = null iff State ≠ Connected\`, enforced by \`ConnectionManager.TransitionTo\`). Two transitions had to be tightened to match:

- \`userDisconnect\`: \`(Connected, some h) → (Disconnecting, **none**)\` — handle dropped atomically on the user-initiated leave.
- \`deviceDisconnected\`: \`(Disconnecting, **none**) → (Disconnected, none)\` — no longer takes an unused \`h\` parameter.

The \`unsolicitedDrop\` constructor was already correct (already drops the handle on the unsolicited leave path).

## Approach

Single inductive predicate \`StateProtocolAgreement\` carried over \`Reaches\`. Preservation closed by \`cases h_step <;> simp\` — every transition either stays inside \`Connected\` (no), enters \`Connected\` with a fresh handle, or leaves \`Connected\` simultaneously with dropping the handle.

## Test plan
- [x] \`lake build\` green (Spec001.BleLifecycle + full project)
- [x] No \`sorry\` / \`admit\` in the file