### PR TITLE
test(spec-001): T025 Lean→C# drift-guard for Boot and BLE state machines

### DIFF
--- a/Tests/Unit/Generators/BleLifecycleTransitionGenerator.cs
+++ b/Tests/Unit/Generators/BleLifecycleTransitionGenerator.cs
@@ -1,0 +1,29 @@
+namespace Tests.Unit.Generators;
+
+/// <summary>
+/// Hand-ported view of the Lean <c>Spec001.BleLifecycle.Step</c>
+/// constructor list (<c>Lean/Spec001/BleLifecycle.lean</c>). Unlike
+/// <see cref="BootTransitionGenerator"/>, the BLE lifecycle does not have
+/// a C# trace-generator on top — <c>ConnectionManagerPropertyTests</c>
+/// exercises the real <c>ConnectionManager</c> directly through fake
+/// <c>ICommunicationPort</c>. This file's only role is to provide the
+/// canonical constructor list that spec-001 T025
+/// (<see cref="LeanDriftGuardTests"/>) compares against the Lean source.
+/// </summary>
+public static class BleLifecycleTransitionGenerator
+{
+    /// <summary>
+    /// Lean-side constructor names of <c>Spec001.BleLifecycle.Step</c>, in
+    /// declaration order. Drift guard against
+    /// <c>Lean/Spec001/BleLifecycle.lean</c>.
+    /// </summary>
+    public static readonly IReadOnlyList<string> LeanStepConstructorNames =
+    [
+        "userConnect",
+        "deviceConnected",
+        "connectFailed",
+        "userDisconnect",
+        "deviceDisconnected",
+        "unsolicitedDrop",
+    ];
+}

--- a/Tests/Unit/Generators/BootTransitionGenerator.cs
+++ b/Tests/Unit/Generators/BootTransitionGenerator.cs
@@ -96,6 +96,27 @@ public static class BootTransitionGenerator
     }
 
     /// <summary>
+    /// Lean-side constructor names of <c>Spec001.BootStateMachine.Step</c>, in
+    /// declaration order. Single source of truth on the C# side for spec-001
+    /// T025 (Lean → FsCheck drift-guard); <see cref="LeanDriftGuardTests"/>
+    /// parses the Lean file and asserts this list matches.
+    /// </summary>
+    public static readonly IReadOnlyList<string> LeanStepConstructorNames =
+    [
+        "startBootInvoked",
+        "startBootAcked",
+        "startBootExhausted",
+        "chunkAcked",
+        "chunkRetry",
+        "chunkExhausted",
+        "uploadComplete",
+        "endBootAcked",
+        "endBootExhausted",
+        "restartAcked",
+        "restartExhausted",
+    ];
+
+    /// <summary>
     /// Discriminator over the 11 Lean transition constructors. Each case maps
     /// 1:1 to a constructor of <c>Spec001.BootStateMachine.Step</c>. The
     /// generator draws from this enum and <see cref="TryApply"/> filters out

--- a/Tests/Unit/Generators/LeanDriftGuardTests.cs
+++ b/Tests/Unit/Generators/LeanDriftGuardTests.cs
@@ -1,0 +1,107 @@
+using System.Text.RegularExpressions;
+
+namespace Tests.Unit.Generators;
+
+/// <summary>
+/// Spec-001 T025 — Lean → C# drift guard. Parses the
+/// <c>inductive Step</c> declaration in each formalized state machine and
+/// asserts the constructor list matches the hand-ported C# array. If a Lean
+/// constructor is added, removed, or renamed without an equivalent C#
+/// update, this test fails — closing the loop on Constitution principle IV
+/// (Lean spec gates the C# tests).
+///
+/// <para>Runs on <c>net10.0</c> only (no Windows-specific dependency). Pure
+/// file parsing, no <c>lake</c> / Lean toolchain required at test time —
+/// the assumption is that the repository's Lean source compiles cleanly
+/// (verified locally during development; CI doesn't yet build Lean).</para>
+/// </summary>
+public class LeanDriftGuardTests
+{
+    [Fact]
+    public void BootStateMachine_LeanInductiveStep_MatchesCSharpHandPort()
+    {
+        var ctors = ParseInductiveStepConstructors("Spec001/BootStateMachine.lean");
+        Assert.Equal(
+            BootTransitionGenerator.LeanStepConstructorNames,
+            ctors);
+    }
+
+    [Fact]
+    public void BleLifecycle_LeanInductiveStep_MatchesCSharpHandPort()
+    {
+        var ctors = ParseInductiveStepConstructors("Spec001/BleLifecycle.lean");
+        Assert.Equal(
+            BleLifecycleTransitionGenerator.LeanStepConstructorNames,
+            ctors);
+    }
+
+    /// <summary>
+    /// Returns the constructor names of the first <c>inductive Step ...</c>
+    /// declaration in the given Lean file, in declaration order.
+    /// </summary>
+    private static IReadOnlyList<string> ParseInductiveStepConstructors(
+        string relativeFromLeanRoot)
+    {
+        var leanFilePath = Path.Combine(LocateLeanRoot(), relativeFromLeanRoot);
+        var lines = File.ReadAllLines(leanFilePath);
+
+        var startIdx = FindLineIndex(lines, l => Regex.IsMatch(l, @"^\s*inductive\s+Step\b"));
+        if (startIdx < 0)
+            throw new InvalidOperationException(
+                $"Could not find `inductive Step` declaration in {leanFilePath}");
+
+        var ctorRegex = new Regex(@"^\s+\|\s+(\w+)");
+        var ctors = new List<string>();
+        for (var i = startIdx + 1; i < lines.Length; i++)
+        {
+            var line = lines[i];
+
+            // End of inductive block: a non-whitespace, non-doc-comment line
+            // starting at column 0 (e.g. the next `inductive`, `def`, `end`).
+            if (line.Length > 0
+                && !char.IsWhiteSpace(line[0])
+                && !line.StartsWith("/-", StringComparison.Ordinal))
+                break;
+
+            var m = ctorRegex.Match(line);
+            if (m.Success)
+                ctors.Add(m.Groups[1].Value);
+        }
+
+        if (ctors.Count == 0)
+            throw new InvalidOperationException(
+                $"Found `inductive Step` in {leanFilePath} but parsed zero constructors");
+
+        return ctors;
+    }
+
+    private static int FindLineIndex(string[] lines, Func<string, bool> predicate)
+    {
+        for (var i = 0; i < lines.Length; i++)
+            if (predicate(lines[i]))
+                return i;
+        return -1;
+    }
+
+    /// <summary>
+    /// Walks up from the test's <see cref="AppContext.BaseDirectory"/>
+    /// looking for a directory that contains <c>Lean/lakefile.lean</c>. That
+    /// directory is the repo root; the Lean root is its <c>Lean/</c>
+    /// subdirectory.
+    /// </summary>
+    private static string LocateLeanRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null
+            && !File.Exists(Path.Combine(dir.FullName, "Lean", "lakefile.lean")))
+        {
+            dir = dir.Parent;
+        }
+        if (dir is null)
+            throw new DirectoryNotFoundException(
+                "Could not locate Lean/ root: walked from "
+                + AppContext.BaseDirectory + " up to filesystem root, no "
+                + "directory with Lean/lakefile.lean found.");
+        return Path.Combine(dir.FullName, "Lean");
+    }
+}


### PR DESCRIPTION
Closes #35.

Adds the spec-001 R3 / T025 drift-guard mechanism: parse the \`inductive Step\` declaration in each Lean spec-001 state machine and assert the constructor list matches a hand-ported C# array. Drift between Lean and C# fails CI.

## What's checked

| Lean source | C# array |
|---|---|
| \`Lean/Spec001/BootStateMachine.lean\` (11 ctors) | \`BootTransitionGenerator.LeanStepConstructorNames\` |
| \`Lean/Spec001/BleLifecycle.lean\` (6 ctors) | \`BleLifecycleTransitionGenerator.LeanStepConstructorNames\` |

## Files

- **\`Tests/Unit/Generators/BootTransitionGenerator.cs\`** — added \`LeanStepConstructorNames\` (11 names, declaration order).
- **\`Tests/Unit/Generators/BleLifecycleTransitionGenerator.cs\`** — new minimal port. No \`Apply\` function: \`ConnectionManagerPropertyTests\` already exercises the real C# \`ConnectionManager\` directly through fake \`ICommunicationPort\`, so a trace generator on top of the Lean BLE machine would be redundant. The file's only role is the canonical constructor list.
- **\`Tests/Unit/Generators/LeanDriftGuardTests.cs\`** — two \`[Fact]\`s. Pure file-parse (regex extracts constructors from the Lean source); no \`lake\` toolchain needed at test time, so CI stays Lean-free. Locates \`Lean/\` via walk-up from the test base directory.

## Test plan
- [x] \`dotnet test --framework net10.0\` green: 332/332 (was 330, +2 drift-guard \`[Fact]\`s)
- [x] Sanity: artificially renaming any Lean ctor would now fail the test (parser is robust to multi-line ctor signatures and trailing doc-comment blocks)

## Out of scope
- BatchComposition drift guard — \`SparkBatchUpdateService\` integration tests cover that side; no hand-port exists in C# and adding one for the drift guard alone would be premature.
- CI-side \`lake build\` invocation — left to a future PR if/when CI gets a Lean toolchain step.