### PR TITLE
docs: record #70 BLE idle-drop resolution (Phase 5 deferral)

### DIFF
--- a/Docs/REFACTOR_PLAN.md
+++ b/Docs/REFACTOR_PLAN.md
@@ -449,6 +449,9 @@ Branch eseguito dopo merge di `phase-4-switch-to-new-stack` per tenere quella PR
 - Nessuna modifica a Core/Services/tab/Form1.
 - Eliminare `Infrastructure.Protocol/Legacy/` e aggiungere `PackageReference Stem.Communication`.
 
+**Acceptance criteria for the new NuGet** (deferred from spec-001):
+- **Connection hold ≥ 60 s idle** (issue #70). The current `Plugin.BLE`-based `BLEManager` lets the BLE link drop within ~5–10 s of idle because `MonitorDeviceConnection` is purely passive. `Stem.Communication`'s BLE adapter must keep the link alive (e.g. periodic descriptor read or connection-parameter refresh) so the operator workaround "click Start upload within ~5 s of connect" can be retired. Validation: ≥ 60 s idle hold on SPARK-UC SN 2225998 with no traffic, no spurious disconnect.
+
 **Valutazione parallela:** migrazione UI da WinForms a WPF (o altro). Questione separata, non blocca l'integrazione NuGet.
 
 ---

--- a/specs/001-spark-ble-fw-stabilize/quickstart.md
+++ b/specs/001-spark-ble-fw-stabilize/quickstart.md
@@ -26,6 +26,10 @@ Firmware binaries live under the team-shared `Docs/Firmwares/` folder (git-ignor
 - SPARK-UC is powered, in advertising range, and not currently connected to any other host.
 - No Visual Studio instance is attached as a debugger during timed runs (it distorts the measurements).
 
+## Known constraints
+
+- **BLE idle-drop window (issue #70).** After the "Connesso al dispositivo" message appears, the BLE link drops within ~5–10 s if no traffic flows. This is a `Plugin.BLE`-on-Windows behavior — the link supervision-timeout fires because nothing keeps it alive. **Operator workaround until the `Stem.Communication` NuGet (Phase 5) lands**: click "Start upload" within ~5 s of connect. Once a firmware upload is in progress, the chunk traffic itself acts as keepalive and the link holds for the full upload, so SC-003 / SC-004 / SC-006 / SC-007 are unaffected. SC-001 / SC-002 are also unaffected (they don't rely on idle-hold).
+
 ## Runbook
 
 Each section maps one-to-one to an SC in the spec.


### PR DESCRIPTION
Closes #70.

Records the **option 1** decision from the issue body (defer the BLE keepalive fix to the future \`Stem.Communication\` NuGet rather than patching \`Infrastructure.Protocol/Legacy/BLE_Manager.cs\` — patching the legacy wrapper would ship code that's already scheduled for deletion in Phase 5).

## Changes

- **\`specs/001-spark-ble-fw-stabilize/quickstart.md\`** — new "Known constraints" section. Documents the operator workaround ("click Start upload within ~5 s of connect") and explicitly notes that SC-001..SC-007 are unaffected because the chunk traffic during a firmware upload keeps the link alive.
- **\`Docs/REFACTOR_PLAN.md\` Phase 5** — adds a new acceptance criterion for the \`Stem.Communication\` NuGet integration: "Connection hold ≥ 60 s idle on SPARK-UC SN 2225998 with no traffic." Locks in the requirement so the fix actually lands before the workaround can be retired.

## Why not patch \`BLE_Manager.cs\` now

\`Infrastructure.Protocol/Legacy/BLE_Manager.cs\` is scheduled for wholesale replacement in Phase 5. A keepalive timer added there would be ~30 LOC of code to port to \`Stem.Communication\` later — a net loss vs. just gating the new NuGet on the keepalive requirement up front.

## Test plan
- [x] No code changes — markdown only
- [x] No spec-001 SC affected (workaround already in operator hands)