### PR TITLE
fix: cache device+board catalog in DictionaryApiProvider

### DIFF
--- a/Infrastructure.Persistence/Api/DictionaryApiProvider.cs
+++ b/Infrastructure.Persistence/Api/DictionaryApiProvider.cs
@@ -13,6 +13,13 @@ public class DictionaryApiProvider : IDictionaryProvider
 {
     private readonly HttpClient _http;
 
+    // Cached device + board catalog. Lives for the lifetime of this provider
+    // (registered as DI singleton, i.e. one app session). The catalog is
+    // server-side metadata and does not change during a session, so there is
+    // no invalidation API — restart the app to pick up server-side changes.
+    private readonly SemaphoreSlim _catalogLock = new(1, 1);
+    private List<(DeviceSummaryDto Device, BoardSummaryDto Board)>? _catalog;
+
     public DictionaryApiProvider(HttpClient httpClient)
     {
         ArgumentNullException.ThrowIfNull(httpClient);
@@ -22,24 +29,15 @@ public class DictionaryApiProvider : IDictionaryProvider
     public async Task<DictionaryData> LoadProtocolDataAsync(
         CancellationToken ct = default)
     {
-        // Carica tutti i device
-        var devices = await _http.GetFromJsonAsync<List<DeviceSummaryDto>>(
-            "api/devices", ct) ?? [];
+        var catalog = await GetCatalogAsync(ct).ConfigureAwait(false);
 
-        // Per ogni device, carica le board e raccogli gli indirizzi
         var addresses = new List<ProtocolAddress>();
-        foreach (var device in devices)
+        foreach (var (device, board) in catalog)
         {
-            var boards = await _http.GetFromJsonAsync<List<BoardSummaryDto>>(
-                $"api/devices/{device.Id}/boards", ct) ?? [];
-
-            foreach (var board in boards)
+            if (!string.IsNullOrWhiteSpace(board.ProtocolAddress))
             {
-                if (!string.IsNullOrWhiteSpace(board.ProtocolAddress))
-                {
-                    addresses.Add(new ProtocolAddress(
-                        device.Name, board.Name, board.ProtocolAddress));
-                }
+                addresses.Add(new ProtocolAddress(
+                    device.Name, board.Name, board.ProtocolAddress));
             }
         }
 
@@ -82,29 +80,65 @@ public class DictionaryApiProvider : IDictionaryProvider
 
     /// <summary>
     /// Cerca tra tutti i device/board quella con ProtocolAddress
-    /// corrispondente al RecipientId hex.
+    /// corrispondente al RecipientId hex. Usa il catalog cached.
     /// </summary>
     private async Task<BoardSummaryDto?> FindBoardByRecipientIdAsync(
         uint recipientId, CancellationToken ct)
     {
         var recipientHex = $"0x{recipientId:X8}";
+        var catalog = await GetCatalogAsync(ct).ConfigureAwait(false);
 
-        var devices = await _http.GetFromJsonAsync<List<DeviceSummaryDto>>(
-            "api/devices", ct) ?? [];
-
-        foreach (var device in devices)
+        foreach (var (_, board) in catalog)
         {
-            var boards = await _http.GetFromJsonAsync<List<BoardSummaryDto>>(
-                $"api/devices/{device.Id}/boards", ct) ?? [];
-
-            var match = boards.FirstOrDefault(b =>
-                string.Equals(b.ProtocolAddress, recipientHex,
-                    StringComparison.OrdinalIgnoreCase));
-
-            if (match is not null)
-                return match;
+            if (string.Equals(board.ProtocolAddress, recipientHex,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return board;
+            }
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Loads the device + board catalog once and caches it for the lifetime
+    /// of this provider. Concurrent first-time callers are serialized via a
+    /// semaphore with a double-check so the fan-out runs exactly once.
+    /// </summary>
+    private async Task<IReadOnlyList<(DeviceSummaryDto Device, BoardSummaryDto Board)>>
+        GetCatalogAsync(CancellationToken ct)
+    {
+        if (_catalog is not null) return _catalog;
+
+        await _catalogLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_catalog is not null) return _catalog;
+
+            var devices = await _http.GetFromJsonAsync<List<DeviceSummaryDto>>(
+                "api/devices", ct).ConfigureAwait(false) ?? [];
+
+            var boardTasks = devices
+                .Select(d => _http.GetFromJsonAsync<List<BoardSummaryDto>>(
+                    $"api/devices/{d.Id}/boards", ct))
+                .ToArray();
+            var boardLists = await Task.WhenAll(boardTasks).ConfigureAwait(false);
+
+            var catalog = new List<(DeviceSummaryDto, BoardSummaryDto)>();
+            for (var i = 0; i < devices.Count; i++)
+            {
+                foreach (var board in boardLists[i] ?? [])
+                {
+                    catalog.Add((devices[i], board));
+                }
+            }
+
+            _catalog = catalog;
+            return catalog;
+        }
+        finally
+        {
+            _catalogLock.Release();
+        }
     }
 }

--- a/Tests/Unit/Infrastructure/DictionaryApiProviderTests.cs
+++ b/Tests/Unit/Infrastructure/DictionaryApiProviderTests.cs
@@ -325,4 +325,63 @@ public class DictionaryApiProviderTests
         Assert.Single(variables);
         Assert.Equal("EdenVar", variables[0].Name);
     }
+
+    // --- Catalog caching (issue #72) ---
+
+    [Fact]
+    public async Task LoadProtocolData_CalledTwice_FetchesDevicesAndBoardsOnce()
+    {
+        var handler = CreateStandardHandler();
+        var provider = CreateProvider(handler);
+
+        var first = await provider.LoadProtocolDataAsync();
+        var second = await provider.LoadProtocolDataAsync();
+
+        Assert.Equal(1, CountListDevicesCalls(handler));
+        Assert.Equal(1, handler.GetCallCount("api/devices/1/boards"));
+        Assert.Equal(1, handler.GetCallCount("api/devices/2/boards"));
+
+        Assert.Equal(first.Addresses.Count, second.Addresses.Count);
+        Assert.Equal(first.Commands.Count, second.Commands.Count);
+    }
+
+    [Fact]
+    public async Task FindBoardByRecipientId_AfterLoadProtocolData_DoesNotRefetchCatalog()
+    {
+        var handler = CreateStandardHandler();
+        var provider = CreateProvider(handler);
+
+        await provider.LoadProtocolDataAsync();
+        var variables = await provider.LoadVariablesAsync(0x00080381);
+
+        Assert.Equal(1, CountListDevicesCalls(handler));
+        Assert.Equal(1, handler.GetCallCount("api/devices/1/boards"));
+        Assert.Equal(1, handler.GetCallCount("api/devices/2/boards"));
+        Assert.Equal(1, handler.GetCallCount("api/dictionaries/100/resolved"));
+        Assert.Equal(2, variables.Count);
+    }
+
+    [Fact]
+    public async Task Concurrent_LoadProtocolData_FetchesDevicesAndBoardsOnce()
+    {
+        var handler = CreateStandardHandler();
+        var provider = CreateProvider(handler);
+
+        var t1 = Task.Run(() => provider.LoadProtocolDataAsync());
+        var t2 = Task.Run(() => provider.LoadProtocolDataAsync());
+        await Task.WhenAll(t1, t2);
+
+        Assert.Equal(1, CountListDevicesCalls(handler));
+        Assert.Equal(1, handler.GetCallCount("api/devices/1/boards"));
+        Assert.Equal(1, handler.GetCallCount("api/devices/2/boards"));
+    }
+
+    // The bare "api/devices" substring also matches "api/devices/{id}/boards".
+    // Count only the listing endpoint by excluding URLs with a trailing path.
+    private static int CountListDevicesCalls(MockHttpMessageHandler handler)
+    {
+        var withSlash = handler.GetCallCount("api/devices/");
+        var total = handler.GetCallCount("api/devices");
+        return total - withSlash;
+    }
 }

--- a/Tests/Unit/Infrastructure/MockHttpMessageHandler.cs
+++ b/Tests/Unit/Infrastructure/MockHttpMessageHandler.cs
@@ -13,6 +13,9 @@ internal class MockHttpMessageHandler : HttpMessageHandler
     private readonly Dictionary<string, (string Json, HttpStatusCode Status)> _responses =
         new(StringComparer.OrdinalIgnoreCase);
 
+    private readonly object _logLock = new();
+    private readonly List<string> _requestLog = [];
+
     private HttpStatusCode _defaultStatus = HttpStatusCode.NotFound;
 
     /// <summary>Registra una risposta JSON per un URL (matching per Contains).</summary>
@@ -28,12 +31,27 @@ internal class MockHttpMessageHandler : HttpMessageHandler
         _defaultStatus = status;
     }
 
+    /// <summary>Returns the number of requests whose URL contained the given substring (case-insensitive).</summary>
+    public int GetCallCount(string urlContains)
+    {
+        lock (_logLock)
+        {
+            return _requestLog.Count(u =>
+                u.Contains(urlContains, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
     protected override Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         var url = request.RequestUri?.ToString() ?? string.Empty;
+
+        lock (_logLock)
+        {
+            _requestLog.Add(url);
+        }
 
         // Matcha le chiavi più lunghe prima (più specifiche)
         foreach (var (key, (json, status)) in _responses


### PR DESCRIPTION
Closes #72.

Eliminates the 1+N HTTP round-trip fan-out on every connect. First call to `DictionaryApiProvider` loads the device + board catalog once (parallel `Task.WhenAll` over per-device boards calls); subsequent operations (`LoadProtocolDataAsync`, `FindBoardByRecipientIdAsync`) reuse it. Cache lives for the lifetime of the provider — i.e. one app session, since the provider is a DI singleton. No invalidation API; app restart is the existing knob.

Steady-state cost per connect drops from ~8 round-trips to 1 (only `/api/dictionaries/{id}/resolved`).

## Approach
- Private `_catalog` field + `SemaphoreSlim` for double-check locked initialization
- `Task.WhenAll` over per-device `/api/devices/{id}/boards` so first-load latency stays low even with many devices
- Public `IDictionaryProvider` surface unchanged
- `/api/commands` is still re-fetched on every `LoadProtocolDataAsync` call (separate, single-call concern)

## Test plan
- [x] `dotnet build` green
- [x] `dotnet test --framework net10.0` green; test count grew by 3 for the new caching `[Fact]`s (335 total, was 332)
- [x] Bench: 10 sequential Connect actions → `/api/devices` + `/api/devices/{id}/boards` hit exactly once across all 10 connects (visual log inspection)