### PR TITLE
chore: remove stale Specs/Phase1 references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@ e Fase 2 (in corso) — services layer + HW adapter + rinomina a pattern Stem.
   - `Core/Interfaces/` — 5 nuove interfacce: `ICommunicationPort` (astrazione CAN/BLE/Serial), `IPacketDecoder` (decoder puro `RawPacket → AppLayerDecodedEvent`), `ITelemetryService`, `IBootService` (+ enum `BootState`, record `BootProgress`), `IDeviceVariantConfig`
   - `Core/Models/` — 6 nuovi modelli: `ConnectionState` (enum), `DeviceVariant` (enum), `DeviceVariantConfig` (record + factory totale `Create(DeviceVariant)`), `RawPacket`, `AppLayerDecodedEvent`, `TelemetryDataPoint`
   - `Core/Models/ImmutableArrayEquality.cs` — helper interno per equality strutturale di `ImmutableArray<byte>` (necessario perché `ImmutableArray<T>.Equals` è reference-based)
-  - `Specs/Phase1/` — 7 file Lean 4 (formalizzazione dei tipi + teoremi di correttezza della factory `DeviceVariantConfig.Create`)
+  - `Specs/Phase1/` — pianificati 7 file Lean 4 (formalizzazione dei tipi + teoremi di correttezza della factory `DeviceVariantConfig.Create`); **non committati**, superati dalla formalizzazione viva in `Lean/Spec001/` (spec-001).
   - `Tests/Unit/Core/Models/` — 6 nuovi file test (33 test): `ConnectionStateTests`, `DeviceVariantTests`, `DeviceVariantConfigTests`, `RawPacketTests`, `AppLayerDecodedEventTests`, `TelemetryDataPointTests`
   - `Docs/PREPROCESSOR_DIRECTIVES.md` — sezione "Nota Fase 1 — IDeviceVariantConfig (TODO per Fase 3)" che elenca i feature flag booleani da aggiungere in Fase 3 per eliminare i blocchi `#if`
 - `.copilot/` — Istruzioni Copilot con memoria a lungo termine, 5 agent files (CODING, TEST, DOCS, ISSUES, FORMAL)

--- a/Core/Interfaces/IBootService.cs
+++ b/Core/Interfaces/IBootService.cs
@@ -6,8 +6,6 @@ namespace Core.Interfaces;
 /// <see cref="BootState.Completed"/> oppure <see cref="BootState.Failed"/>.
 ///
 /// Implementazione concreta in Fase 2: <c>Services/Boot/BootService</c>.
-///
-/// Formalizzazione: <c>Specs/Phase1/Interfaces.lean</c>.
 /// </summary>
 public interface IBootService
 {

--- a/Core/Interfaces/ICommunicationPort.cs
+++ b/Core/Interfaces/ICommunicationPort.cs
@@ -19,8 +19,6 @@ namespace Core.Interfaces;
 /// <item><see cref="PacketReceived"/>: emesso per ogni pacchetto ricevuto.</item>
 /// <item><see cref="StateChanged"/>: emesso a ogni transizione di stato.</item>
 /// </list>
-///
-/// Formalizzazione: <c>Specs/Phase1/Interfaces.lean</c>.
 /// </summary>
 public interface ICommunicationPort : IDisposable
 {

--- a/Core/Interfaces/IDeviceVariantConfig.cs
+++ b/Core/Interfaces/IDeviceVariantConfig.cs
@@ -8,8 +8,6 @@ namespace Core.Interfaces;
 ///
 /// In Fase 1 espone solo le proprietà base. In Fase 3 saranno aggiunti
 /// feature flag booleani — vedi <c>Docs/PREPROCESSOR_DIRECTIVES.md</c>.
-///
-/// Formalizzazione: <c>Specs/Phase1/Interfaces.lean</c>.
 /// </summary>
 public interface IDeviceVariantConfig
 {

--- a/Core/Interfaces/IPacketDecoder.cs
+++ b/Core/Interfaces/IPacketDecoder.cs
@@ -7,9 +7,6 @@ namespace Core.Interfaces;
 /// Non ha stato né side effect, deve essere deterministico.
 ///
 /// Implementazione concreta in Fase 2: <c>Services/Protocol/PacketDecoder</c>.
-///
-/// Formalizzazione: <c>Specs/Phase1/Interfaces.lean</c> (teorema
-/// <c>decoder_is_deterministic</c>).
 /// </summary>
 public interface IPacketDecoder
 {

--- a/Core/Interfaces/ITelemetryService.cs
+++ b/Core/Interfaces/ITelemetryService.cs
@@ -7,8 +7,6 @@ namespace Core.Interfaces;
 /// e l'emissione di <see cref="TelemetryDataPoint"/>.
 ///
 /// Implementazione concreta in Fase 2: <c>Services/Telemetry/TelemetryService</c>.
-///
-/// Formalizzazione: <c>Specs/Phase1/Interfaces.lean</c>.
 /// </summary>
 public interface ITelemetryService
 {

--- a/Core/Models/AppLayerDecodedEvent.cs
+++ b/Core/Models/AppLayerDecodedEvent.cs
@@ -6,8 +6,6 @@ namespace Core.Models;
 /// Evento applicativo decodificato, emesso da <c>IPacketDecoder</c>.
 /// Contiene il comando, la variabile opzionale, il payload raw e
 /// l'identità del mittente.
-///
-/// Vedi <c>Specs/Phase1/AppLayerDecodedEvent.lean</c> per la formalizzazione.
 /// </summary>
 /// <param name="Command">Comando decodificato dal pacchetto.</param>
 /// <param name="Variable">Variabile associata (solo per comandi di read/write variabile). Null negli altri casi.</param>

--- a/Core/Models/ConnectionState.cs
+++ b/Core/Models/ConnectionState.cs
@@ -2,7 +2,6 @@ namespace Core.Models;
 
 /// <summary>
 /// Stato di una <c>ICommunicationPort</c>.
-/// Vedi <c>Specs/Phase1/ConnectionState.lean</c> per la formalizzazione.
 /// </summary>
 public enum ConnectionState
 {

--- a/Core/Models/DeviceVariant.cs
+++ b/Core/Models/DeviceVariant.cs
@@ -4,8 +4,6 @@ namespace Core.Models;
 /// Variante del device. Rimpiazza i simboli di preprocessore
 /// <c>#if TOPLIFT/EDEN/EGICON</c> con un valore a runtime letto da
 /// <c>appsettings.json</c>.
-///
-/// Vedi <c>Specs/Phase1/DeviceVariant.lean</c> per la formalizzazione.
 /// </summary>
 public enum DeviceVariant
 {

--- a/Core/Models/DeviceVariantConfig.cs
+++ b/Core/Models/DeviceVariantConfig.cs
@@ -8,7 +8,7 @@ namespace Core.Models;
 /// (vedi <c>Docs/PREPROCESSOR_DIRECTIVES.md</c> blocco #7).
 ///
 /// In Fase 1 sono esposte solo le 4 proprietà base. I feature flag booleani
-/// saranno aggiunti in Fase 3. Vedi <c>Specs/Phase1/DeviceVariantConfig.lean</c>.
+/// saranno aggiunti in Fase 3.
 /// </summary>
 /// <param name="Variant">Variante del device.</param>
 /// <param name="DefaultRecipientId">RecipientId fisso. 0 = risolvere per nome a runtime.</param>

--- a/Core/Models/RawPacket.cs
+++ b/Core/Models/RawPacket.cs
@@ -6,8 +6,6 @@ namespace Core.Models;
 /// Pacchetto raw ricevuto da una <c>ICommunicationPort</c>.
 /// Non ancora decodificato a livello applicativo (per quello vedi
 /// <see cref="AppLayerDecodedEvent"/>).
-///
-/// Vedi <c>Specs/Phase1/RawPacket.lean</c> per la formalizzazione.
 /// </summary>
 /// <param name="Payload">Byte del pacchetto. Equality strutturale garantita da <see cref="Equals(RawPacket)"/>.</param>
 /// <param name="Timestamp">Istante di ricezione.</param>

--- a/Core/Models/TelemetryDataPoint.cs
+++ b/Core/Models/TelemetryDataPoint.cs
@@ -13,8 +13,6 @@ namespace Core.Models;
 /// a one-shot read (<c>CMD_READ_VARIABLE</c> reply) lo invia in big-endian. Usare
 /// <see cref="NumericValueLittleEndian"/> o <see cref="NumericValueBigEndian"/> per
 /// decodificare secondo l'origine del campione.</para>
-///
-/// Vedi <c>Specs/Phase1/TelemetryDataPoint.lean</c> per la formalizzazione.
 /// </summary>
 /// <param name="Variable">Variabile dizionario a cui il campione si riferisce.</param>
 /// <param name="RawValue">Valore grezzo. Equality strutturale garantita da <see cref="Equals(TelemetryDataPoint)"/>.</param>

--- a/Core/README.md
+++ b/Core/README.md
@@ -122,17 +122,11 @@ var packet = new RawPacket(
 
 ## Formalizzazioni Lean 4
 
-I tipi introdotti in Fase 1 sono formalizzati in [`Specs/Phase1/`](../Specs/Phase1/README.md) (Lean 4):
-
-| File Lean | Corrispettivo C# |
-|-----------|------------------|
-| `ConnectionState.lean` | `Models/ConnectionState.cs` |
-| `DeviceVariant.lean` | `Models/DeviceVariant.cs` |
-| `DeviceVariantConfig.lean` | `Models/DeviceVariantConfig.cs` |
-| `RawPacket.lean` | `Models/RawPacket.cs` |
-| `AppLayerDecodedEvent.lean` | `Models/AppLayerDecodedEvent.cs` |
-| `TelemetryDataPoint.lean` | `Models/TelemetryDataPoint.cs` |
-| `Interfaces.lean` | `Interfaces/*.cs` |
+The Phase 1 Lean files were never committed; the live formalization lives under
+[`Lean/Spec001/`](../Lean/Spec001/) (spec-001 — Spark BLE Firmware Stabilization)
+and covers the boot state machine, BLE lifecycle, and batch composition with
+preservation theorems. See `specs/001-spark-ble-fw-stabilize/data-model.md` for
+the entity → Lean type mapping.
 
 ---
 
@@ -147,6 +141,6 @@ I tipi introdotti in Fase 1 sono formalizzati in [`Specs/Phase1/`](../Specs/Phas
 - [README Soluzione](../README.md)
 - [Infrastructure.Persistence](../Infrastructure.Persistence/README.md)
 - [Tests](../Tests/README.md)
-- [Specs/Phase1](../Specs/Phase1/README.md)
+- [Lean/Spec001 — Lean 4 formalizations](../Lean/Spec001/)
 - [REFACTOR_PLAN](../Docs/REFACTOR_PLAN.md)
 - [PREPROCESSOR_DIRECTIVES](../Docs/PREPROCESSOR_DIRECTIVES.md)

--- a/Docs/REFACTOR_PLAN.md
+++ b/Docs/REFACTOR_PLAN.md
@@ -41,7 +41,7 @@ Ogni branch: PR → review → squash merge in main. Non procedere alla fase suc
 
 **Obiettivo:** Estrarre interfacce e contratti nel layer Core per comunicazione e hardware.
 
-**Esito:** branch eseguito come `refactor/protocol-abstractions`. Aggiunti 5 interfacce + 6 modelli + helper di equality strutturale in `Core/`, 33 test in `Tests/Unit/Core/Models/`, 7 file Lean 4 in `Specs/Phase1/`. Build + test verdi (86 net10.0 / 138 net10.0-windows). I feature flag booleani su `IDeviceVariantConfig` sono rimandati a Fase 3 — vedi nota in `Docs/PREPROCESSOR_DIRECTIVES.md`.
+**Esito:** branch eseguito come `refactor/protocol-abstractions`. Aggiunti 5 interfacce + 6 modelli + helper di equality strutturale in `Core/`, 33 test in `Tests/Unit/Core/Models/`. La formalizzazione Lean 4 di `Specs/Phase1/` (7 file) era prevista ma **non è mai stata committata**; la formalizzazione viva è ora in `Lean/Spec001/` (spec-001 — boot/BLE/batch state machines + preservation theorems). Build + test verdi (86 net10.0 / 138 net10.0-windows). I feature flag booleani su `IDeviceVariantConfig` sono rimandati a Fase 3 — vedi nota in `Docs/PREPROCESSOR_DIRECTIVES.md`.
 
 ### 1.1 Interfacce Core
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Stem.Device.Manager/
 - [Piano di refactoring architetturale](./Docs/REFACTOR_PLAN.md)
 - [Protocollo STEM — funzionamento interno](./Docs/PROTOCOL.md)
 - [Direttive preprocessore (#if)](./Docs/PREPROCESSOR_DIRECTIVES.md)
-- [Specs/Phase1 — formalizzazioni Lean 4](./Specs/Phase1/README.md)
+- [Lean/Spec001 — formalizzazioni Lean 4](./Lean/Spec001/)
 - [CHANGELOG](./CHANGELOG.md)
 - [LICENSE](./LICENSE)
 

--- a/Tests/Unit/Core/Models/DeviceVariantConfigTests.cs
+++ b/Tests/Unit/Core/Models/DeviceVariantConfigTests.cs
@@ -5,7 +5,6 @@ namespace Tests.Unit.Core.Models;
 
 /// <summary>
 /// Test per DeviceVariantConfig e la factory Create.
-/// Verifica la corrispondenza con la formalizzazione Lean in Specs/Phase1/DeviceVariantConfig.lean.
 /// </summary>
 public class DeviceVariantConfigTests
 {


### PR DESCRIPTION
Closes #39.

The \`Specs/Phase1/\` Lean files were described aspirationally in \`CLAUDE.md\` but were never actually committed. The live Lean 4 formalization lives under [\`Lean/Spec001/\`](../tree/main/Lean/Spec001) (spec-001 — boot/BLE/batch state machines + preservation theorems T1..T5).

This PR cleans the 16 stale references by **deleting** the dead pointers (option 1 from the issue body). Where the reference was load-bearing for context (CHANGELOG / REFACTOR_PLAN), the historical mention is preserved but annotated as never committed and superseded by \`Lean/Spec001/\`.

## What changed

| File group | Action |
|---|---|
| \`Core/Interfaces/*.cs\` (5) | Drop \`Formalizzazione: <c>Specs/Phase1/Interfaces.lean</c>\` lines |
| \`Core/Models/*.cs\` (6) | Drop \`Vedi <c>Specs/Phase1/X.lean</c>\` lines |
| \`Tests/Unit/Core/Models/DeviceVariantConfigTests.cs\` | Drop the stale "Verifica la corrispondenza con la formalizzazione Lean…" comment |
| \`Core/README.md\` | Replace Phase 1 mapping table + link with a pointer to \`Lean/Spec001/\` and the spec-001 \`data-model.md\` |
| \`README.md\` | Redirect the root Lean link from \`Specs/Phase1/\` to \`Lean/Spec001/\` |
| \`CHANGELOG.md\`, \`Docs/REFACTOR_PLAN.md\` | Annotate the historical Phase 1 mention as never-committed; point at \`Lean/Spec001/\` |

## Test plan
- [x] \`dotnet build Core/Core.csproj\` green, 0 warnings (XML doc edits don't break the build)
- [x] No remaining stale \`Specs/Phase1/\` refs that could be misread as live links — the only remaining hits are in CHANGELOG/REFACTOR_PLAN where they're now explicitly framed as historical context

## Out of scope
- Backfilling Phase 1 Lean files (option 2 from the issue) — Spec001 already covers the live formalization needs; redoing the original Phase 1 plan would be busywork.