### PR TITLE
chore: log or tighten silent catch(Exception) sites

### DIFF
--- a/GUI.Windows/Forms/Form1.cs
+++ b/GUI.Windows/Forms/Form1.cs
@@ -25,6 +25,7 @@ namespace StemPC
         // propaga ConnectionStatusChanged al port.
         private readonly SerialPortManager _serialPortManager;
         private readonly BLEManager _bleManager;
+        private readonly ILogger<Form1> _logger;
 
         public const string Software_Version = "2.15";
 
@@ -100,6 +101,7 @@ namespace StemPC
             _variantConfig = serviceProvider.GetRequiredService<IDeviceVariantConfig>();
             _serialPortManager = serviceProvider.GetRequiredService<SerialPortManager>();
             _bleManager = serviceProvider.GetRequiredService<BLEManager>();
+            _logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<Form1>();
 
             // Canale hardware di default dalla variante.
             CurrentChannel = _variantConfig.DefaultChannel;
@@ -139,7 +141,9 @@ namespace StemPC
             //crea e aggiungi il ble manager. Il tab riceve la stessa istanza BLEManager
             //registrata in DI come IBleDriver del BlePort: scan+connect sul tab → BlePort
             //vede ConnectionStatusChanged → port Connected → SendAsync funziona.
-            BLETabRef = new BLEInterfaceTab(_bleManager, _connMgr);
+            BLETabRef = new BLEInterfaceTab(
+                _bleManager, _connMgr,
+                _serviceProvider.GetService<ILoggerFactory>());
             tabControl.TabPages.Add(BLETabRef);
 
             // Sottoscrivi log driver BLE al terminale UI + errori driver BLE/Serial al MessageBox.
@@ -454,6 +458,7 @@ namespace StemPC
             }
             catch (Exception ex)
             {
+                _logger.LogError(ex, "SendPS_Async failed.");
                 ShowDriverError("Errore invio",
                     $"Invio fallito ({ex.GetType().Name}): {ex.Message}");
             }
@@ -735,6 +740,7 @@ namespace StemPC
             }
             catch (Exception ex)
             {
+                _logger.LogError(ex, "SwitchChannelAsync failed for channel {Channel}.", kind);
                 MessageBox.Show($"Switch canale fallito: {ex.Message}", "Errore", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }

--- a/GUI.Windows/Tabs/BLE_WF_Tab.cs
+++ b/GUI.Windows/Tabs/BLE_WF_Tab.cs
@@ -3,6 +3,8 @@ using GUI.Windows;
 
 using GUI.Windows.Properties;
 using Infrastructure.Protocol.Legacy;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Services.Cache;
 
 public partial class BLEInterfaceTab : TabPage
@@ -23,13 +25,19 @@ public partial class BLEInterfaceTab : TabPage
     // C3 source into ConnectionState.Connected. Without this the manager stays at
     // Disconnected / ActiveProtocol=null after a reconnect post-drop (spec-001 #55).
     private readonly ConnectionManager _connMgr;
+    private readonly ILogger<BLEInterfaceTab> _logger;
 
-    public BLEInterfaceTab(BLEManager bleManager, ConnectionManager connMgr)
+    public BLEInterfaceTab(
+        BLEManager bleManager,
+        ConnectionManager connMgr,
+        ILoggerFactory? loggerFactory = null)
     {
         ArgumentNullException.ThrowIfNull(bleManager);
         ArgumentNullException.ThrowIfNull(connMgr);
         this.bleManager = bleManager;
         _connMgr = connMgr;
+        _logger = (loggerFactory ?? NullLoggerFactory.Instance)
+            .CreateLogger<BLEInterfaceTab>();
         InitializeComponent();
     }
 
@@ -153,6 +161,9 @@ public partial class BLEInterfaceTab : TabPage
                 }
                 catch (Exception ex)
                 {
+                    _logger.LogError(ex,
+                        "SwitchToAsync(Ble) failed after connecting to {DeviceName}.",
+                        deviceName);
                     MessageBox.Show(
                         $"Switch canale fallito: {ex.Message}",
                         "Errore",

--- a/GUI.Windows/Tabs/Spark_FirmwareUpdate_WF_Tab.cs
+++ b/GUI.Windows/Tabs/Spark_FirmwareUpdate_WF_Tab.cs
@@ -14,6 +14,7 @@ public sealed class Spark_FirmwareUpdate_WF_Tab : TabPage
 {
     private readonly ConnectionManager _connMgr;
     private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger<Spark_FirmwareUpdate_WF_Tab> _logger;
     private readonly Dictionary<SparkFirmwareArea, AreaRow> _rows = new();
     private Button _btnUpdate = null!;
     private Label _lblStatus = null!;
@@ -26,6 +27,7 @@ public sealed class Spark_FirmwareUpdate_WF_Tab : TabPage
         ArgumentNullException.ThrowIfNull(connMgr);
         _connMgr = connMgr;
         _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+        _logger = _loggerFactory.CreateLogger<Spark_FirmwareUpdate_WF_Tab>();
 
         Name = "tabPageSparkFirmware";
         Text = "SPARK Firmware Update";
@@ -269,6 +271,7 @@ public sealed class Spark_FirmwareUpdate_WF_Tab : TabPage
         }
         catch (Exception ex)
         {
+            _logger.LogError(ex, "Unexpected error during SPARK firmware update.");
             SetStatus("Unexpected error.");
             MessageBox.Show(
                 $"Unexpected error during firmware update:\n\n{ex.Message}",

--- a/GUI.Windows/Tabs/TopLift_Telemetry_WF_Tab.cs
+++ b/GUI.Windows/Tabs/TopLift_Telemetry_WF_Tab.cs
@@ -833,7 +833,7 @@ public class TopLiftTelemetry_Tab : TabPage
                 MessageBox.Show("Parameters saved succesfully:\n" + sfd.FileName,
                                 "Save Parameters", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
                 MessageBox.Show("Errore in saving parameters:\n" + ex.Message,
                                 "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -884,7 +884,7 @@ public class TopLiftTelemetry_Tab : TabPage
                 MessageBox.Show("Parameters loaded succesfully from:\n" + ofd.FileName,
                                 "Load Parameters", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
                 MessageBox.Show("Error loading parameters:\n" + ex.Message,
                                 "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);


### PR DESCRIPTION
Closes #52.

Audit of `catch (Exception)` sites that previously swallowed silently. Surfaced during spec-001 T006 bench runs; was producing first-chance `System.Exception` notifications in the VS Output window with no companion log line.

## Approach

Grep `catch\s*\(\s*Exception` over `*.cs`, triage into:
- **Already logs / rethrows** — left alone (20 sites). All of `Infrastructure.Protocol/Legacy/{BLE_Manager,SerialPort_Manager}` and `Infrastructure.Protocol/Hardware/PCANManager` already surface via `ErrorOccurred?.Invoke`/`Debug.WriteLine`/`throw`. `Services/Boot/SparkBatchUpdateService` rethrows wrapped via `throw Fail(...)`. The 3 stress-test catches in `PacketReassemblerTests`/`PacketDecoderTests` collect into a list that is asserted via `Assert.Empty(exceptions)` — not silent.
- **Terminal teardown / Dispose** — none in the literal `catch (Exception)` scope. (Two bare `catch { /* best effort */ }` in `Hardware/SerialPort.cs:126` and `Hardware/CanPort.cs:142` are out of audit scope but already commented.)
- **Silent and non-terminal** — fixed (6 sites). UI handlers that only opened a `MessageBox` with `ex.Message` (loses the exception object and stack trace).

For bucket-c, preference order: existing `_logger.Log*` if a logger was already a dep (most cases), else narrow the catch to a specific exception type. Form1 acquires `ILogger<Form1>` from the existing `IServiceProvider`. `Spark_FirmwareUpdate_WF_Tab` already had `ILoggerFactory`. `BLEInterfaceTab` gained an optional `ILoggerFactory` ctor param (Form1 supplies it via `_serviceProvider.GetService<ILoggerFactory>()`). `TopLiftTelemetry_Tab` had no logger — file-IO catches narrowed to `IOException`/`UnauthorizedAccessException` instead of plumbing one in for two sites.

## Sites changed

- `GUI.Windows/Forms/Form1.cs:459` — added `_logger.LogError(ex, "SendPS_Async failed.")` before the existing `ShowDriverError` MessageBox.
- `GUI.Windows/Forms/Form1.cs:741` — added `_logger.LogError(ex, "SwitchChannelAsync failed for channel {Channel}.", kind)` before the existing MessageBox.
- `GUI.Windows/Forms/Form1.cs` (ctor) — added `private readonly ILogger<Form1> _logger` resolved via `serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<Form1>()`.
- `GUI.Windows/Tabs/Spark_FirmwareUpdate_WF_Tab.cs:274` — added `_logger.LogError(ex, "Unexpected error during SPARK firmware update.")` before the existing MessageBox; cached `ILogger<Spark_FirmwareUpdate_WF_Tab>` from the existing `_loggerFactory`.
- `GUI.Windows/Tabs/BLE_WF_Tab.cs:164` — added `_logger.LogError(ex, "SwitchToAsync(Ble) failed after connecting to {DeviceName}.", deviceName)` before the existing MessageBox; ctor gained an optional `ILoggerFactory` parameter.
- `GUI.Windows/Tabs/TopLift_Telemetry_WF_Tab.cs:836,887` — narrowed both file-IO catches from `catch (Exception ex)` to `catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)`.
- `GUI.Windows/Forms/Form1.cs:142` — pass `ILoggerFactory` to the new `BLEInterfaceTab` ctor.

## Residuals

None. The repo-wide grep confirms that every remaining `catch (Exception)` either logs (Debug.WriteLine, ErrorOccurred event, or _logger.Log*), rethrows (wrapped or bare), or is captured into a list that is asserted on. No new abstractions introduced; no logger plumbed for the sake of two file-IO catches.

## Test plan
- [x] `dotnet build Stem.Device.Manager.slnx -c Release -p:EnableWindowsTargeting=true` — green, 0 warnings, 0 errors.
- [x] `dotnet test Tests/Tests.csproj --framework net10.0` — 335 passed, 0 failed.
- [x] `dotnet test Tests/Tests.csproj --framework net10.0-windows10.0.19041.0` — 526 passed, 0 failed.