### PR TITLE
fix: PCANManager wraps inner exception in IOException, preserves stack

### DIFF
--- a/Infrastructure.Protocol/Hardware/PCANManager.cs
+++ b/Infrastructure.Protocol/Hardware/PCANManager.cs
@@ -282,7 +282,9 @@ public class PCANManager : IPcanDriver
         }
         catch (Exception ex)
         {
-            throw new Exception($"Errore durante l'invio del pacchetto {canMessage.DATA}: {ex.Message}");
+            throw new IOException(
+                $"Failed to write CAN frame (ID 0x{canMessage.ID:X}, {canMessage.LEN} bytes).",
+                ex);
         }
         return result;
     }


### PR DESCRIPTION
Closes #91.

Three-bug fix on \`Infrastructure.Protocol/Hardware/PCANManager.cs:285\`. The pre-fix line was:

\`\`\`csharp
throw new Exception(\$\"Errore durante l'invio del pacchetto {canMessage.DATA}: {ex.Message}\");
\`\`\`

After:

\`\`\`csharp
throw new IOException(
    \$\"Failed to write CAN frame (ID 0x{canMessage.ID:X}, {canMessage.LEN} bytes).\",
    ex);
\`\`\`

## What's fixed

| # | Bug | Resolution |
|---|---|---|
| 1 | Inner \`ex\` lost (concatenated into string, not passed as \`innerException\`) | \`ex\` is now the second arg → \`InnerException\` is set, full stack preserved |
| 2 | Bare \`Exception\` type — callers can't catch specifically | \`IOException\` (semantically right for hardware-write failure) |
| 3 | \`{canMessage.DATA}\` interpolation produced the literal \`\"System.Byte[]\"\` | Replaced with \`ID 0x<hex> + LEN bytes\` (the actually-useful diagnostic info) |
| 4 | Message in Italian (last Italian leak in Infrastructure.Protocol) | Translated to English per constitution principle VI |

## Test plan
- [x] \`dotnet build Infrastructure.Protocol/Infrastructure.Protocol.csproj -p:EnableWindowsTargeting=true\` — green, 0 warnings
- [x] \`dotnet test --framework net10.0\` — 335/335 green
- [x] \`dotnet test --framework net10.0-windows10.0.19041.0\` — 526/526 green
- [x] \`grep \"throw new Exception(\" --type cs\` repo-wide → 0 hits