### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,387 +1,394 @@
 ﻿# Changelog
 
-Tutte le modifiche rilevanti a questo progetto sono documentate in questo file.
+All notable changes to this project are documented in this file.
 
-Il formato si basa su [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-### Legenda
+### Legend
 
-- **Added**: Nuove funzionalità
-- **Changed**: Modifiche a funzionalità esistenti
-- **Deprecated**: Funzionalità che verranno rimosse
-- **Removed**: Funzionalità rimosse
-- **Fixed**: Bug corretti
-- **Security**: Vulnerabilità corrette
+- **Added**: new features
+- **Changed**: changes to existing functionality
+- **Deprecated**: features marked for removal
+- **Removed**: features removed
+- **Fixed**: bug fixes
+- **Security**: vulnerability fixes
 
 ---
 
 ## [Unreleased]
 
-Modernizzazione: documentazione, standard, riorganizzazione progetto, test coverage,
-architettura multi-progetto, migrazione dizionari Excel → API Azure,
-Fase 3 disaccoppiamento Form1 (Branch 1+2 completati), rimozione funzionalità ButtonPanel e ExcelHandler,
-refactor architetturale (REFACTOR_PLAN) con Fase 1 — protocol abstractions in Core —
-e Fase 2 (in corso) — services layer + HW adapter + rinomina a pattern Stem.
-
-### Added
-
-- **spec-001 — Spark BLE Firmware Stabilization** (see `specs/001-spark-ble-fw-stabilize/`). Closes the post-Phase 4 stabilization debt against the SPARK-UC reference bench. Five user stories landed across PRs #41..#85:
-  - **US1 — Close/relaunch is crash-free**: structured `ShutdownAudit` (Debug-only) + event-handler unsubscription fixes in `ConnectionManager`/`BLEManager`. Bench acceptance: 0 `ObjectDisposedException` over 10 close/relaunch cycles.
-  - **US2 — UI state matches reality**: `ConnectionManager.TransitionTo` private mutator funnels every state change through a single site so the C1 biconditional (`ActiveProtocol != null ⇔ State == Connected`) holds by construction. `BlePort.StateChanged` wired into `TransitionTo(Disconnected)`. `BlePort.Dispose` now awaits driver disconnect (closes #50). FsCheck `C1_StateProtocolBiconditional` + `C3_NoUnexpectedTransitions` codify the contract.
-  - **US3 — BLE session survives a full upload**: `BootService` retry-budget audit against contract Q1/Q2/Q3/I1; transient errors retry up to `RetryBudget`, session-drop fails immediately. FsCheck property tests Q1/Q2/Q3/I1 in `BootStateMachinePropertyTests`.
-  - **US4 — Multi-file batch is all-success or abort-on-first-failure**: FR-010 empty-firmware precondition rejects batches up-front; `SparkBatchUpdateService` end-of-batch `RESTART_MACHINE` only (closes #74) — STEM firmware shuts down on restart, so the per-area restart broke areas 2..N.
-  - **US5 — HMI upload time budget (SC-004)**: bench investigation `Docs/PerfRegression-Spec001.md` recorded that the ~2× regression motivating SC-004 is no longer reproducing on `main` as of 2026-04-27. T020 root-cause fix skipped; T021 single-run guard (`Us5_Hmi_Upload_WithinV215_Budget`) is the safety net.
-  - **Lean 4 formalization** (`Lean/Spec001/`): `BootStateMachine` (T1 offset-total, T2 retry-bounded, T3 terminal stability, T4 phase preservation), `BleLifecycle` (T5 state-protocol biconditional), `BatchComposition` (succeeded → all-completed, failed → area-in-input). `lake build` green, no `sorry`/`admit`.
-  - **Lean → C# drift guard** (`LeanDriftGuardTests`): parses the `inductive Step` declarations in each Lean file and asserts the constructor list matches the hand-ported C# arrays in `BootTransitionGenerator`/`BleLifecycleTransitionGenerator`. Fails CI on any divergence.
-  - **Observability (FR-009)**: structured `ILogger.BeginScope` `{ Area, Step, Attempt, Recipient }` in `BootService` + `ConnectionManager`; one `LogInformation` per state transition, one `LogWarning` per retry. Discard-frame logging in `ProtocolService` receive path (#76 / PR #77).
-  - **Bench operations**: `Docs/BenchLog-Spec001.md` seeded for chronological per-run logging across SC-001..SC-007.
-- **REFACTOR_PLAN Fase 3 — Branch 2 `refactor/phase-3-tab-decoupling`** (in corso, secondo sub-branch di Fase 3):
-  - `Services/Cache/DictionaryCache.SetCurrentRecipientId(uint)` — mutazione pura di `CurrentRecipientId` senza HTTP call né `DictionaryUpdated` event (per loop multi-board in `Boot_Smart_Tab` dove il dizionario variabili non cambia)
-  - `Boot_Interface_Tab` — ctor injection di `DictionaryCache`, legge `_cache.CurrentRecipientId` invece di `Form1.FormRef.RecipientId`
-  - `Boot_Smart_Tab` — ctor injection di `DictionaryCache`, sottoscrive `DictionaryUpdated` per aggiornare `MachineDictionary`, rimosso metodo pubblico `UpdateDictionary(IReadOnlyList<Variable>)`. Nel loop multi-board line 300 chiama sia `_cache.SetCurrentRecipientId(X)` (nuovo) sia `Form1.FormRef.RecipientId = X` (parità legacy: `STEM_protocol.cs` legge ancora `FormRef.RecipientId`, rimosso in Phase 4)
-  - `Telemetry_Tab` — ctor injection di `DictionaryCache`, sottoscrive `DictionaryUpdated` (marshalling BeginInvoke per aggiornare ComboBox), rimosso `UpdateDictionary`
-  - `TopLiftTelemetry_Tab` — ctor injection di `DictionaryCache`, sottoscrive `DictionaryUpdated`, rimosso `UpdateDictionary`
-  - `Form1.cs` — resolve `DictionaryCache` via DI, passa la cache al ctor dei 4 tab. `LoadDictionaryDataAsync` usa ora `_dictionaryCache.LoadAsync`/`_dictionaryCache.SelectByRecipientAsync` (una singola chiamata HTTP, notifica tab via `DictionaryUpdated`). Rimosse tutte le chiamate a `TelemetryTabRef.UpdateDictionary(Dizionario)`/`BootSmartTabRef.UpdateDictionary(Dizionario)`/`TLTTabRef.UpdateDictionary(Dizionario)` (5 call-site in Form1)
-  - `Tests/Unit/Tabs/TabDependencyInjectionTests.cs` — 5 smoke test Windows-only: null-ctor throw per 4 tab + propagation `DictionaryCache.LoadAsync` → `DictionaryUpdated`
-  - Test: **+5 test Windows-only** → suite **270 net10.0** / **448 net10.0-windows**
-  - `Tests/Tests.csproj` — esclude `Unit/Tabs/**` dal target net10.0 (tab referenziano WinForms)
-  - **Scope skip:** `BLE_WF_Tab.cs` e `CAN_WF_Tab.cs` esclusi dal refactor (nessun consumer dizionario, nessun ref a `Form1.FormRef.RecipientId`)
-  - **Scope legacy:** `TelemetryManager`/`BootManager` dentro i tab restano invariati (Phase 4 rimuoverà lo stack `STEMProtocol/`)
-- **REFACTOR_PLAN Fase 3 — Branch 1 `refactor/phase-3-dictionary-cache`** (in corso, primo sub-branch di Fase 3):
-  - `Core/Interfaces/IDeviceVariantConfig.DefaultChannel` — nuova proprietà `ChannelKind` (TOPLIFT→Can, altre varianti→Ble per parità legacy)
-  - `Core/Models/DeviceVariantConfig` — aggiunto record param + helper `DefaultChannelFor(variant)`; factory aggiornata
-  - `Core/Interfaces/IPacketDecoder.UpdateDictionary` — promosso al contratto (era solo su `PacketDecoder` concreto). Necessario per `DictionaryCache`
-  - `Services/Cache/DictionaryCache.cs` — singleton centralizzato per dizionario STEM:
-    - properties `Commands`/`Addresses`/`Variables`/`CurrentRecipientId` thread-safe
-    - `LoadAsync` (commands+addresses), `SelectByRecipientAsync` (variables per uint), `SelectByDeviceBoardAsync` (lookup device+board → recipient)
-    - aggiorna automaticamente lo snapshot di `IPacketDecoder` ad ogni mutazione
-    - emette evento `DictionaryUpdated` per i consumer (tab Phase 3)
-    - parità legacy: niente cache LRU sulle variabili
-  - `Services/Cache/ConnectionManager.cs` — gestore canale attivo + factory `IProtocolService` runtime:
-    - aggrega `IEnumerable<ICommunicationPort>` (3 port da `AddProtocolInfrastructure`)
-    - `ActiveChannel`/`ActiveProtocol` (null finché `SwitchToAsync` non chiamato)
-    - `SwitchToAsync(ChannelKind)`: dispose protocol vecchio → disconnect vecchia port → connect nuova → crea nuovo `ProtocolService`
-    - eventi `ActiveChannelChanged` + `StateChanged` (snapshot `(ChannelKind, ConnectionState)`)
-    - stato iniziale = `IDeviceVariantConfig.DefaultChannel`, nessun auto-connect (consumer controlla timing)
-  - `Services/DependencyInjection.cs` — registra `DictionaryCache` + `ConnectionManager` come singleton
-  - `Infrastructure.Protocol/DependencyInjection.cs` — espone `CanPort`/`BlePort`/`SerialPort` anche come `ICommunicationPort` (factory delegata ai singleton concreti per identità)
-  - Test: **+47 test** (4 DeviceVariantConfig.DefaultChannel + 14 DictionaryCache + 18 ConnectionManager + 5 wiring DI) → suite **268 net10.0** / **441 net10.0-windows**
-  - `ConnectionManagerTests` Windows-only (richiede real `CanPort`/`BlePort`/`SerialPort` con fake driver) — file escluso esplicitamente da target net10.0 in `Tests.csproj`
-- **REFACTOR_PLAN — Branch `refactor/protocol-interface`** (merged in main, PR #28, prerequisite di Fase 3 + chiusura debito Fase 2 integration tests):
-  - `Core/Interfaces/IProtocolService.cs` — nuovo contratto del facade protocollo (`SenderId`, `AppLayerDecoded`, `SendCommandAsync`, `SendCommandAndWaitReplyAsync`, estende `IDisposable`)
-  - `Services/Protocol/ProtocolService` implementa `IProtocolService` (nessun cambio signature pubblica)
-  - `TelemetryService` e `BootService` ctor — dipendenza da `IProtocolService` invece di `ProtocolService` concreto. Suite test esistente verde senza modifiche
-  - `Tests/Unit/Services/DependencyInjection/AddServicesTests.cs` — **11 test cross-platform** per `Services.AddServices(IConfiguration)`: smoke resolve, override `Device:Variant`/`Device:SenderId`, fallback su SenderId invalido, singleton lifetime, null guards
-  - `Tests/Unit/Infrastructure/Protocol/AddProtocolInfrastructureTests.cs` — **8 test Windows-only** per `Infrastructure.Protocol.AddProtocolInfrastructure()`: ServiceDescriptor per IPcanDriver/CanPort/BlePort/SerialPort, resolve con fake driver registrati esternamente, conferma contratto "host registra IBleDriver/ISerialDriver prima"
-  - Test: **+19 test** (11 cross-platform + 8 Windows-only) → suite **247 net10.0** / **400 net10.0-windows**
-- **REFACTOR_PLAN Fase 2 — Branch C `refactor/services-di-integration`** (merged in main, PR #27, Step 7 completato — chiude Fase 2):
-  - `Core/Interfaces/IDeviceVariantConfig.SenderId` — nuova proprietà uint (indirizzo STEM del mittente, default `8` per parità legacy)
-  - `Core/Models/DeviceVariantConfig` — record esteso con `SenderId`; `DefaultSenderId = 8` costante; nuovo overload `Create(variant, senderId)`; il single-arg delega al default
-  - `Services/Configuration/DeviceVariantConfigFactory.FromString(variant, senderId)` — overload per host DI che legge SenderId da appsettings
-  - `Services/DependencyInjection.cs` — `AddServices(IConfiguration)`: registra `IDeviceVariantConfig` (da `Device:Variant` + `Device:SenderId`) e `IPacketDecoder` vuoto (UpdateDictionary chiamato dal consumer post-load Azure)
-  - `Infrastructure.Protocol/DependencyInjection.cs` — `AddProtocolInfrastructure()`: registra `PCANManager` come `IPcanDriver`, e `CanPort`/`BlePort`/`SerialPort` come singleton concreti (NON come `ICommunicationPort`: scelta runtime gestita in Phase 3 da `ConnectionManager`)
-  - `Services.csproj` + `Infrastructure.Protocol.csproj` — aggiunti PackageRef `Microsoft.Extensions.DependencyInjection.Abstractions 10.0.5` (e `Configuration.Abstractions` per Services)
-  - `App/appsettings.json` — `Device.SenderId = 8`
-  - `App/Program.cs` — wiring DI completo: `AddDictionaryProvider` + driver BLE/Serial registrati come `IBleDriver`/`ISerialDriver` + `AddProtocolInfrastructure()` + `AddServices(config)`. Nessun consumer cambiato (Form1 continua a usare `STEMProtocol/` legacy — rimozione in Phase 3)
-  - **Servizi NON registrati per scelta architetturale**: `ProtocolService`, `ITelemetryService`, `IBootService` dipendono dalla port runtime (CAN/BLE/Serial scelta a menu) — creati dal `ConnectionManager` in Phase 3
-  - `Docs/PREPROCESSOR_DIRECTIVES.md` — documentato debito Phase 3: `BLE_Manager.FormRef` da rimpiazzare con evento o `ILogger`
-  - Test: **+8 test** (6 DeviceVariantConfig SenderId + 2 DeviceVariantConfigFactory) → suite **236 net10.0** / **381 net10.0-windows**
-- **REFACTOR_PLAN Fase 2 — Branch B `refactor/services-business`** (merged in main 2026-04-20, PR #26, Step 3-5 completati):
-  - `Services/Configuration/DeviceVariantConfigFactory.cs` — factory totale: parsing case-insensitive da stringa di configurazione (default Generic per null/vuoto/sconosciuto), helper `CanonicalName` per round-trip
-  - `App/appsettings.json` — sezione `Device:Variant` (default `"Generic"`)
-  - `Services/Telemetry/TelemetryService.cs` — implementa `ITelemetryService` usando `ProtocolService` come facade (zero ref a `ICommunicationPort`/`IPacketDecoder` diretti, zero ref a Form1):
-    - protocollo CMD_CONFIGURE_TELEMETRY (0x0015) / CMD_START_TELEMETRY (0x0016) / CMD_STOP_TELEMETRY (0x0017)
-    - decode CMD_TELEMETRY_DATA (0x0018) per uint8/uint16/uint32 LE — variabili a DataType ignoto saltate
-    - state machine stopped/running con `Lock`, `UpdateDictionary` atomico, pacchetti a telemetria spenta ignorati
-  - `Services/Boot/BootService.cs` — implementa `IBootService` usando `ProtocolService.SendCommandAndWaitReplyAsync` per il pattern request/reply:
-    - sequenza upload: CMD_START_PROCEDURE → loop blocchi 1024B (paddati 0xFF) di CMD_PROGRAM_BLOCK con 10 retry → CMD_END_PROCEDURE con 5 retry → CMD_RESTART_MACHINE x 2
-    - reply matching tramite convenzione "CodeHigh=80 → risposta"
-    - fwType estratto da byte 14-15 little-endian del firmware
-    - state machine Idle → Uploading → (Completed | Failed) con `Lock`; `BootProtocolException` interna assorbita (parità legacy: stato Failed osservabile, niente rethrow)
-    - `CancellationToken` rispettato fra blocchi
-    - ctor interno con `responseTimeout` + `restartInterval` configurabili (per test veloci)
-  - `Core/Interfaces/IBootService` — aggiunto parametro `uint recipientId` a `StartFirmwareUploadAsync` (target device)
-  - `Services/Protocol/ProtocolService.SenderId` — getter pubblico per accesso al senderId interno (usato da TelemetryService per payload CONFIGURE)
-  - `Tests/Unit/Services/Protocol/FakeCommunicationPort` — hook `OnSent` opzionale per auto-reply nei test BootService
-  - Test: **+56 test** (25 DeviceVariantConfigFactory + 18 TelemetryService + 13 BootService), tutti cross-platform → suite **228 net10.0** / **373 net10.0-windows**
-- **REFACTOR_PLAN Fase 2 — Branch A `refactor/protocol-service`** (merged in main 2026-04-20, PR #25, Step 6 completato):
-  - `Core/Models/ChannelKind.cs` — enum Can/Ble/Serial per discriminare il framing atteso dal protocollo
-  - `Core/Interfaces/ICommunicationPort` — aggiunta proprietà `ChannelKind Kind { get; }` (i 3 adapter esistenti la espongono)
-  - `Services/Protocol/NetInfo.cs` — struct immutable (readonly record struct) per parsing/encoding dei 2 byte Network Layer (remainingChunks 10 bit, setLength 1 bit, packetId 3 bit, version 2 bit)
-  - `Services/Protocol/PacketReassembler.cs` — riassembly multi-chunk thread-safe per packetId con `Reset()` e `PendingPacketCount` per diagnostica
-  - `Services/Protocol/ProtocolService.cs` — facade del protocollo: encode command → TP con CRC16 Modbus → chunking per canale → wire frame; decode + reassembly + evento `AppLayerDecoded`; pattern `SendCommandAndWaitReplyAsync` con validator custom e timeout
-  - Mantenuto quirk storico senderId byte-swap (parità con legacy TransportLayer, vedi PROTOCOL.md §3.1)
-  - Test: +49 test (13 NetInfo + 13 PacketReassembler + 13 ProtocolService + 3 Kind adapter + 7 altri), tutti cross-platform tranne Kind per adapter (Windows-only)
-- **REFACTOR_PLAN Fase 2 — Branch `refactor/services-foundation`** (merged in main 2026-04-20, PR #24, Step 1-2 completati):
-  - **Rinomina** progetto `Infrastructure` → `Infrastructure.Persistence` per allineamento al pattern Stem (`Infrastructure.<Concern>` — vedi `Stem.Production.Tracker`, `Stem.ButtonPanel.Tester`)
-  - **Nuovo progetto** `Infrastructure.Protocol` (dual TFM `net10.0;net10.0-windows10.0.19041.0`) — adapter hardware CAN/BLE/Serial:
-    - `Hardware/CanPort.cs` — implementa `ICommunicationPort` con convention A (arbitration ID LE prefisso nei payload) wrappando `PCANManager` via `IPcanDriver`
-    - `Hardware/BlePort.cs` — implementa `ICommunicationPort` con convention pass-through, wrappa `App.BLEManager` via `IBleDriver`
-    - `Hardware/SerialPort.cs` — implementa `ICommunicationPort` con convention pass-through, wrappa `App.SerialPortManager` via `ISerialDriver`
-    - `Hardware/IPcanDriver.cs` / `IBleDriver.cs` / `ISerialDriver.cs` — abstraction per testability + dependency inversion (`BLEManager` e `SerialPortManager` restano in `App/` per Form1/MessageBox refs)
-    - `Hardware/BlePacketEventArgs.cs` / `SerialPacketEventArgs.cs` — event args centralizzati
-    - `Hardware/PCANManager.cs` — driver PCAN-USB spostato da `App/` (auto-reconnect, baud rate runtime)
-  - **`Services/` ora popolato** (target `net10.0` puro, cross-platform):
-    - `Services/Protocol/PacketDecoder.cs` — `IPacketDecoder` puro con thread-safe `UpdateDictionary` (Volatile.Read/Write su snapshot)
-    - `Services/Protocol/DictionarySnapshot.cs` — snapshot immutabile con lookup comandi/variabili/indirizzi (hex case-insensitive)
-  - `Docs/PROTOCOL.md` — nuova documentazione completa del protocollo STEM (3 livelli AL/TL/NL, NetInfo bit layout, CRC16 Modbus, chunking per canale, 10 comandi noti, 6 known quirks, pipeline send/receive per canale, roadmap migrazione Fase 4)
-  - Test coverage: **274 test** totali (era 209), **132 cross-platform** (era 86): +27 PacketDecoder, +21 DictionarySnapshot, +22 CanPort, +21 BlePort, +21 SerialPort, +7 PacketEventArgs, +18 gap-fill (Dispose idempotency, connect timeout, state cycle, null validation)
-  - `CanPort` / `BlePort` / `SerialPort` tests usano fake driver manuali (`FakePcanDriver`, `FakeBleDriver`, `FakeSerialDriver`) in `Tests/Unit/Infrastructure/Protocol/`
-  - README progetti: `Infrastructure.Protocol/README.md`, `Services/README.md`; `Infrastructure.Persistence/README.md` aggiornato post-rename
-- **REFACTOR_PLAN Fase 1 — Protocol abstractions in Core** (branch `refactor/protocol-abstractions`):
-  - `Core/Interfaces/` — 5 nuove interfacce: `ICommunicationPort` (astrazione CAN/BLE/Serial), `IPacketDecoder` (decoder puro `RawPacket → AppLayerDecodedEvent`), `ITelemetryService`, `IBootService` (+ enum `BootState`, record `BootProgress`), `IDeviceVariantConfig`
-  - `Core/Models/` — 6 nuovi modelli: `ConnectionState` (enum), `DeviceVariant` (enum), `DeviceVariantConfig` (record + factory totale `Create(DeviceVariant)`), `RawPacket`, `AppLayerDecodedEvent`, `TelemetryDataPoint`
-  - `Core/Models/ImmutableArrayEquality.cs` — helper interno per equality strutturale di `ImmutableArray<byte>` (necessario perché `ImmutableArray<T>.Equals` è reference-based)
-  - `Specs/Phase1/` — pianificati 7 file Lean 4 (formalizzazione dei tipi + teoremi di correttezza della factory `DeviceVariantConfig.Create`); **non committati**, superati dalla formalizzazione viva in `Lean/Spec001/` (spec-001).
-  - `Tests/Unit/Core/Models/` — 6 nuovi file test (33 test): `ConnectionStateTests`, `DeviceVariantTests`, `DeviceVariantConfigTests`, `RawPacketTests`, `AppLayerDecodedEventTests`, `TelemetryDataPointTests`
-  - `Docs/PREPROCESSOR_DIRECTIVES.md` — sezione "Nota Fase 1 — IDeviceVariantConfig (TODO per Fase 3)" che elenca i feature flag booleani da aggiungere in Fase 3 per eliminare i blocchi `#if`
-- `.copilot/` — Istruzioni Copilot con memoria a lungo termine, 5 agent files (CODING, TEST, DOCS, ISSUES, FORMAL)
-- `Docs/Standards/` — Template standard (README, ISSUES, STANDARD, TEMPLATE_STANDARD)
-- `README.md` — Documentazione root del progetto
-- `CHANGELOG.md` — Questo file
-- `LICENSE` — Licenza proprietaria
-- `Stem.Device.Manager.slnx` — Solution file migrato a formato XML moderno (da `.sln`)
-- `Tests/` — Progetto test xUnit con 176 test (xUnit 2.5.3)
-  - **Unit test** (68): Core Models, Infrastructure providers (API/Excel/Fallback), Terminal, Protocol, CodeGenerator, CircularProgressBar
-  - **Integration test** (34): DI wiring con IDictionaryProvider, CodeGenerator E2E, Form1 IDictionaryProvider integration
-  - **Manual mocks**: MockHttpMessageHandler, MockDictionaryProvider
-- `App/README.md` — Documentazione progetto App
-- `Tests/README.md` — Documentazione progetto Tests
-- `Core/README.md` — Documentazione progetto Core
-- `Infrastructure/README.md` — Documentazione progetto Infrastructure
-- `Docs/PREPROCESSOR_DIRECTIVES.md` — Documentazione blocchi `#if` nel codice, strategia Fase 3
-- `InternalsVisibleTo("Tests")` in `App.csproj` per testare tipi `internal`
-- **Architettura multi-progetto** — Migrazione da monolite a 4 progetti separati:
-  - `Core/` (net10.0) — Modelli dominio, interfacce (`IDictionaryProvider`)
-  - `Infrastructure/` (net10.0) — Provider dati (API Azure + Excel + Fallback decorator)
-  - `Services/` (net10.0-windows) — Pronto per logica business futura
-  - `App/` (net10.0-windows) — Windows Forms, DI configurato con `IConfiguration`
-- **Migrazione dizionari Excel → API Azure** (Fase 2 completata):
-  - `Core/Models/` — 4 record dominio: `Variable`, `Command`, `ProtocolAddress`, `DictionaryData`
-  - `Core/Interfaces/IDictionaryProvider` — Astrazione async con `CancellationToken`
-  - `Infrastructure/Excel/ExcelDictionaryProvider` — Legge da Excel embedded, ora unica implementazione Excel
-  - `Infrastructure/Api/DictionaryApiProvider` — Chiama API REST Stem.Dictionaries.Manager
-  - `Infrastructure/Api/Dtos/` — 5 DTO deserializzazione (struttura JSON reale dell'API)
-  - `Infrastructure/Api/DictionaryApiOptions` — Configurazione: BaseUrl, ApiKey, TimeoutSeconds
-  - `Infrastructure/FallbackDictionaryProvider` — Decorator: API → catch HttpRequestException → Excel
-  - `Infrastructure/DependencyInjection.cs` — Extension method `AddDictionaryProvider(IConfiguration)`
-  - `App/appsettings.json` — Sezione `DictionaryApi` (vuota = Excel, popolata = API con fallback)
-  - `Docs/MIGRATION_API.md` — Piano migrazione completo con 6 branch documentati
-- **Fase 3 Branch 1: `refactor/type-swap-core-models`** — Sostituzione tipi ExcelHandler con Core.Models
-  - `App/Form1.cs`, `App/TelemetryManager.cs`, `App/*_WF_Tab.cs` — Rinominate proprietà (es. `AddrH→AddressHigh`)
-- **Fase 3 Branch 2: `refactor/source-swap-idictionary-provider`** — Sostituzione ExcelHandler come sorgente dati
-  - `App/Form1.cs` — Iniettato `IDictionaryProvider`, estratto `LoadDictionaryDataAsync(CancellationToken)`,
-    `comboBoxBoard_SelectedIndexChanged` reso `async void`
-  - Eliminati 6 blocchi `#if TOPLIFT/#else` relativi al caricamento
-  - `Docs/PREPROCESSOR_DIRECTIVES.md` — Documentati 9 blocchi `#if` rimasti con strategia di refactoring
-  - `Tests/Integration/Form1/` — 9 test di integrazione + `MockDictionaryProvider` per il contratto IDictionaryProvider
-
-### Changed
-
-- **Migrazione .NET 8 → .NET 10** — TFM `net10.0-windows10.0.19041.0` per App e Tests
-- `bitbucket-pipelines.yml` — image `sdk:10.0`, build via `.slnx` (supportato da SDK 10)
-- Rinominato progetto da `STEMPM` ad `App` (cartella `App/`, file `App.csproj`)
-- Migrato solution file da `.sln` (legacy) a `.slnx` (XML moderno, ~58% riduzione righe)
-- Build configurations ridotte da 10 a 8 (rimossa `STEMDM`, rimossa `BUTTONPANEL`)
-- `bitbucket-pipelines.yml` — aggiunto step Test dopo Build
-- `README.md` — aggiornato badge test (0 → 176), struttura soluzione multi-progetto, caratteristiche, build config
-- `App/Program.cs` — Aggiunto `IConfiguration` (appsettings.json + env vars) e `AddDictionaryProvider()`
-- `App/App.csproj` — Aggiunto `ProjectReference` a Core e Infrastructure, pacchetti Configuration, rimosso BUTTONPANEL config
-- Namespace `App.Core.*` → `Core.*` per modelli e interfacce spostati in Core/
-- `App/README.md` — Rimosso ButtonPanel e ExcelHandler da struttura e build config, LOC 56k → 54k
-- `Core/README.md` — Rimosso ButtonPanel da modelli e interfacce
-- `Tests/README.md` — Aggiornato test count 272 → 176, rimosso ButtonPanel test suite, rimosso ExcelHandler test suite
-- `Docs/PREPROCESSOR_DIRECTIVES.md` — Rimosso BUTTONPANEL da simboli attivi, documentata rimozione nella sezione "Eliminati"
-- `CLAUDE.md` — Rimosso ButtonPanel da componenti chiave, aggiornato numero configurazioni build 9 → 8
-- `README.md` (root) — Rimosso "Dizionari Excel embedded", aggiornato a "Dizionari Azure API"
-
-### Removed
-
-- **Removed**: legacy `Boot_Interface_Tab` (`Boot_WF_Tab.cs`) and its 3 null-arg DI tests; `Spark_FirmwareUpdate_WF_Tab` is the canonical bootloader UI. Closes #78, closes #57.
-- Configurazione `STEMDM` — mai usata, nessun `#if STEMDM` nel codice
-- **Configurazione build `BUTTONPANEL`** — Funzionalità test pulsantiere rimossa interamente
-- **Modulo ButtonPanel completo** — Rimozione in 6 fasi:
-  - Fase 1: Test ButtonPanel (7 file, 34 test unit, 8 test integration)
-  - Fase 2: Disconnessione da Form1 e Program.cs (metodi, blocchi `#if BUTTONPANEL`, registrazione DI)
-  - Fase 3: Interfaccia e servizi (IButtonPanelTestService, ButtonPanelTestService, MVP presenter/view)
-  - Fase 4: Modelli core (ButtonPanel, ButtonPanelTestResult, ButtonPanelEnums, ButtonIndicator)
-  - Fase 5: Configurazione build (rimosso da `<Configurations>` in App.csproj)
-  - Fase 6: Risorse e documentazione (cartella images/ButtonPanels/, aggiornamento README)
-- **ExcelHandler.cs rimosso completamente** — Migrato a Infrastructure.ExcelDictionaryProvider
-  - Rimozione logica da Form1, tab WinForms e TelemetryManager
-  - Eliminazione di ExcelHandler.cs, ExcelHandler test (8 unit + 1 integration)
-  - Semplificazione: nessun più ExcelfilePath, isStreamBased, MessageBox per errori Excel
-  - IDictionaryProvider unificato: form usa infrastructure provider
-- `Core/Models/ButtonPanel.cs` — Factory e maschere bit
-- `Core/Models/ButtonPanelTestResult.cs` — DTO risultato test
-- `Core/Models/ButtonIndicator.cs` — Indicatore visuale stato pulsante
-- `Core/Enums/ButtonPanelEnums.cs` — 6 enum (ButtonPanelType, TestType, IndicatorState, pulsanti)
-- `Core/Interfaces/IButtonPanelTestService.cs` — Contratto servizio collaudo
-- `App/Services/ButtonPanelTestService.cs` — Implementazione servizio (~250 LOC)
-- `App/GUI/Presenters/ButtonPanelTestPresenter.cs` — Presenter MVP (157 LOC)
-- `App/GUI/Views/ButtonPanelTestTabControl.cs` — UserControl WinForms (579 LOC)
-- `App/GUI/Views/ButtonPanelTestTabControl.Designer.cs` — Auto-generated WinForms
-- `App/Core/Interfaces/IButtonPanelTestTab.cs` — Contratto vista
-- `App/images/ButtonPanels/` — Cartella con 4 immagini JPG (risorse pulsantiere)
-- Test ButtonPanel:
-  - `Tests/Unit/Core/Models/ButtonPanelTests.cs` (10 test)
-  - `Tests/Unit/Core/Models/ButtonPanelTestResultTests.cs` (3 test)
-  - `Tests/Unit/Core/Models/ButtonIndicatorTests.cs` (2 test)
-  - `Tests/Unit/Core/Enums/ButtonPanelEnumsTests.cs` (8 test)
-  - `Tests/Integration/Presenter/ButtonPanelTestPresenterTests.cs` (8+ test)
-  - `Tests/Integration/Presenter/Mocks/MockButtonPanelTestTab.cs`
-  - `Tests/Integration/Presenter/Mocks/MockButtonPanelTestService.cs`
-- `Stem.Device.Manager.sln` — sostituito da `.slnx`
-
-### Fixed
-
-- **spec-001 / issue #74 — `SparkBatchUpdateService` end-of-batch restart only.** `RESTART_MACHINE` (CMD `0x000A`) was firing once per area in a multi-area batch, but SPARK firmware shuts the device down on restart, preventing areas 2..N from running. Per STEM firmware-team confirmation (2026-04-27), `RESTART_MACHINE` is hoisted out of `RunAreaAsync` and fires exactly once at the end of the batch, addressed to the HMI board recipient (`0x000702C1`). On the abort path no restart fires — recovery from a half-flashed device is operator-driven. Single-file `IBootService.StartFirmwareUploadAsync` is unchanged. Tests + `Docs/PROTOCOL.md` §8 + `specs/001-spark-ble-fw-stabilize/data-model.md` updated to reflect the batch composition.
-- Blocchi `#if BUTTONPANEL` rimossi da `Form1.cs` (righe ~156, ~344)
-- Blocchi `#if BUTTONPANEL` rimossi da `SplashScreen.cs` (riga ~12)
-- ExcelHandler decoupled da Form1: nessun più chiamate dirette a `hExcel.EstraiDizionario()`
+_No unreleased changes yet._
 
 ---
 
-### Statistiche rimozione ButtonPanel e ExcelHandler
+## [0.3.0] - 2026-04-29
 
-- **File eliminati**: 27 (19 ButtonPanel + 8 ExcelHandler-related)
-- **File modificati**: 15 (Form1, SplashScreen, Program, App.csproj, ServiceRegistrationTests, + 6 README, CLAUDE.md, CHANGELOG, etc.)
-- **Test rimossi**: 142 (34 ButtonPanel + 8 ExcelHandler)
-- **Test rimanenti**: 176 ✅ (tutti passanti)
-- **Linee di codice rimosse**: ~1.500
-- **LOC App**: 56k → 54k
-- **Build configurations**: 9 → 8
-- **Codice semplificato**: Form1 no longer references ExcelHandler, IDictionaryProvider unico entry point
+First SemVer release after the modernization wave (legacy versioning was `2.x`,
+reset to `0.3.0` to align with SemVer and reflect the still-evolving public surface).
+
+This release covers everything between the legacy `0.2.15` (commit `80bf9c6`) snapshot
+and today: full modernization (multi-project architecture, Azure dictionary API,
+Form1 decomposition, removal of `#if`-based device variants, Spark BLE firmware
+stabilization, Lean 4 invariants, dual-TFM tests).
+
+### Added
+
+- **spec-001 — Spark BLE Firmware Stabilization** (see `specs/001-spark-ble-fw-stabilize/`).
+  Closes the post-Phase 4 stabilization debt against the SPARK-UC reference bench. Five
+  user stories landed across PRs #41..#85:
+  - **US1 — Close/relaunch is crash-free**: structured `ShutdownAudit` (Debug-only) +
+    event-handler unsubscription fixes in `ConnectionManager`/`BLEManager`. Bench
+    acceptance: 0 `ObjectDisposedException` over 10 close/relaunch cycles.
+  - **US2 — UI state matches reality**: `ConnectionManager.TransitionTo` private
+    mutator funnels every state change through a single site so the C1 biconditional
+    (`ActiveProtocol != null ⇔ State == Connected`) holds by construction.
+    `BlePort.StateChanged` wired into `TransitionTo(Disconnected)`. `BlePort.Dispose`
+    now awaits driver disconnect (closes #50). FsCheck `C1_StateProtocolBiconditional`
+    + `C3_NoUnexpectedTransitions` codify the contract.
+  - **US3 — BLE session survives a full upload**: `BootService` retry-budget audit
+    against contract Q1/Q2/Q3/I1; transient errors retry up to `RetryBudget`,
+    session-drop fails immediately. FsCheck property tests Q1/Q2/Q3/I1 in
+    `BootStateMachinePropertyTests`.
+  - **US4 — Multi-file batch is all-success or abort-on-first-failure**: FR-010
+    empty-firmware precondition rejects batches up-front; `SparkBatchUpdateService`
+    end-of-batch `RESTART_MACHINE` only (closes #74) — STEM firmware shuts down on
+    restart, so the per-area restart broke areas 2..N.
+  - **US5 — HMI upload time budget (SC-004)**: bench investigation
+    `Docs/PerfRegression-Spec001.md` recorded that the ~2× regression motivating
+    SC-004 is no longer reproducing on `main` as of 2026-04-27. T020 root-cause fix
+    skipped; T021 single-run guard (`Us5_Hmi_Upload_WithinV215_Budget`) is the
+    safety net.
+  - **Lean 4 formalization** (`Lean/Spec001/`): `BootStateMachine` (T1
+    offset-total, T2 retry-bounded, T3 terminal stability, T4 phase preservation),
+    `BleLifecycle` (T5 state-protocol biconditional), `BatchComposition` (succeeded
+    → all-completed, failed → area-in-input). `lake build` green, no `sorry`/`admit`.
+  - **Lean → C# drift guard** (`LeanDriftGuardTests`): parses the `inductive Step`
+    declarations in each Lean file and asserts the constructor list matches the
+    hand-ported C# arrays in `BootTransitionGenerator` /
+    `BleLifecycleTransitionGenerator`. Fails CI on any divergence.
+  - **Observability (FR-009)**: structured `ILogger.BeginScope`
+    `{ Area, Step, Attempt, Recipient }` in `BootService` + `ConnectionManager`;
+    one `LogInformation` per state transition, one `LogWarning` per retry.
+    Discard-frame logging in `ProtocolService` receive path (#76 / PR #77).
+  - **Bench operations**: `Docs/BenchLog-Spec001.md` seeded for chronological
+    per-run logging across SC-001..SC-007.
+
+- **REFACTOR_PLAN Phase 4 — `refactor/phase-4-switch-to-new-stack`** (merged):
+  switched `Form1` and the WinForms tabs to the new stack
+  (`ConnectionManager.ActiveProtocol`, `CurrentBoot`, `CurrentTelemetry`); removed
+  the legacy `GUI.Windows/STEMProtocol/` folder (~2590 LOC) and the corresponding
+  `BootManager` / `TelemetryManager` shims. Drivers `BLEManager` /
+  `SerialPortManager` moved to `Infrastructure.Protocol/Legacy/`.
+
+- **REFACTOR_PLAN Phase 3** (merged in main, PRs #29–#32):
+  - **Branch 1 — `refactor/phase-3-dictionary-cache`**: `DictionaryCache` singleton
+    (commands + addresses + variables + `CurrentRecipientId`), `ConnectionManager`
+    aggregating the three ports and exposing `ActiveChannel` / `ActiveProtocol` /
+    `StateChanged`. `IDeviceVariantConfig.DefaultChannel` (TopLift→CAN, others→BLE
+    for legacy parity). DI registration in `Services/DependencyInjection.cs` +
+    factory bridges in `Infrastructure.Protocol/DependencyInjection.cs`.
+  - **Branch 2 — `refactor/phase-3-tab-decoupling`**: WinForms tabs receive
+    `DictionaryCache` via constructor injection and subscribe to
+    `DictionaryUpdated`; the legacy public `UpdateDictionary(...)` methods on tabs
+    were removed and replaced by event-driven updates.
+    `Form1.LoadDictionaryDataAsync` is now a single HTTP call funneled through the
+    cache.
+  - **Branch 3 — `refactor/phase-3-form1-thin-shell`**: `Form1` reduced to a thin
+    shell (~731 LOC), composition of `ConnectionManager` + `DictionaryCache` +
+    `IDeviceVariantConfig` from the service provider; `SendPS_Async` uses
+    `ConnectionManager.ActiveProtocol`; RX path subscribes to
+    `ConnectionManager.AppLayerDecoded`.
+  - **Branch 4 — `refactor/remove-ifs`**: removal of all `#if TOPLIFT/EDEN/EGICON`
+    blocks. The device variant is now selected at runtime via `Device:Variant` in
+    `appsettings.json` consumed by `IDeviceVariantConfig`. Build configurations
+    reduced to `Debug` and `Release` only.
+
+- **REFACTOR_PLAN — `refactor/protocol-interface`** (merged, PR #28):
+  prerequisite for Phase 3 + closure of the Phase 2 integration-test debt.
+  - `Core/Interfaces/IProtocolService.cs` — facade contract (`SenderId`,
+    `AppLayerDecoded`, `SendCommandAsync`, `SendCommandAndWaitReplyAsync`,
+    `IDisposable`).
+  - `Services/Protocol/ProtocolService` implements `IProtocolService`.
+  - `TelemetryService` and `BootService` now depend on `IProtocolService`.
+  - **+19 tests** for `Services.AddServices(IConfiguration)` and
+    `Infrastructure.Protocol.AddProtocolInfrastructure()`.
+
+- **REFACTOR_PLAN Phase 2** (merged in main 2026-04-20, PRs #24–#27):
+  - **Branch A — `refactor/protocol-service`**: `ChannelKind` enum,
+    `ICommunicationPort.Kind`, `NetInfo` struct (NL bit layout), thread-safe
+    `PacketReassembler`, and the `ProtocolService` facade (encode/decode TP +
+    CRC16 Modbus + per-channel chunking + request/reply pattern). +49 cross-platform
+    tests.
+  - **Branch B — `refactor/services-business`**: `TelemetryService`
+    (CMD_CONFIGURE/START/STOP_TELEMETRY + decoding of CMD_TELEMETRY_DATA) and
+    `BootService` (CMD_START_PROCEDURE → 1024-byte blocks → CMD_END_PROCEDURE →
+    CMD_RESTART_MACHINE x2, retry budget, `CancellationToken` honored between
+    blocks). +56 cross-platform tests.
+  - **Branch C — `refactor/services-di-integration`**:
+    `IDeviceVariantConfig.SenderId` (default 8 for legacy parity);
+    `Services.AddServices(IConfiguration)` +
+    `Infrastructure.Protocol.AddProtocolInfrastructure()`. `ProtocolService`,
+    `ITelemetryService`, `IBootService` are intentionally **not** registered — they
+    depend on the runtime-selected port and are created by `ConnectionManager`.
+  - **Branch — `refactor/services-foundation`**: renamed `Infrastructure` →
+    `Infrastructure.Persistence`; new `Infrastructure.Protocol` project (dual TFM)
+    hosting `CanPort` / `BlePort` / `SerialPort`; `Services/` populated with
+    `PacketDecoder` (thread-safe `UpdateDictionary` via `Volatile.Read/Write` on
+    snapshots) and `DictionarySnapshot`. `Docs/PROTOCOL.md` written from scratch.
+    Test count rose from 209 to 274.
+
+- **REFACTOR_PLAN Phase 1 — Protocol abstractions in Core**
+  (branch `refactor/protocol-abstractions`):
+  - 5 new `Core/Interfaces/`: `ICommunicationPort`, `IPacketDecoder`,
+    `ITelemetryService`, `IBootService` (+ `BootState` enum, `BootProgress`
+    record), `IDeviceVariantConfig`.
+  - 6 new `Core/Models/`: `ConnectionState`, `DeviceVariant`, `DeviceVariantConfig`
+    (record + total factory `Create(DeviceVariant)`), `RawPacket`,
+    `AppLayerDecodedEvent`, `TelemetryDataPoint`.
+  - `Core/Models/ImmutableArrayEquality.cs` — internal helper for structural
+    equality of `ImmutableArray<byte>`.
+  - `Tests/Unit/Core/Models/` — 6 new test files (33 tests).
+
+- **Excel → Azure dictionary API migration** (Phase 2):
+  - `Core/Models/`: 4 domain records (`Variable`, `Command`, `ProtocolAddress`,
+    `DictionaryData`).
+  - `Core/Interfaces/IDictionaryProvider` — async abstraction with
+    `CancellationToken`.
+  - `Infrastructure.Persistence/Excel/ExcelDictionaryProvider` — reads from the
+    embedded Excel resource.
+  - `Infrastructure.Persistence/Api/DictionaryApiProvider` — calls the
+    Stem.Dictionaries.Manager REST API; 5 DTOs match the real JSON shape.
+  - `Infrastructure.Persistence/FallbackDictionaryProvider` — decorator
+    (API → catch `HttpRequestException` → Excel).
+  - `AddDictionaryProvider(IConfiguration)` extension method.
+  - `appsettings.json` — `DictionaryApi` section.
+
+- **Multi-project architecture** — migration from a monolith to four/five projects
+  (`Core`, `Infrastructure.Persistence`, `Infrastructure.Protocol`, `Services`,
+  `GUI.Windows`).
+
+- **`.copilot/`** — Copilot long-term-memory instructions, 5 agent files
+  (CODING, TEST, DOCS, ISSUES, FORMAL).
+- **`Docs/Standards/`** — reusable standards (README, ISSUES, STANDARD,
+  TEMPLATE_STANDARD).
+- **`README.md`** — project root documentation.
+- **`CHANGELOG.md`** — this file.
+- **`LICENSE`** — proprietary license.
+- **`Stem.Device.Manager.slnx`** — solution file migrated to the modern XML format.
+- **`Tests/`** — xUnit project, dual TFM (`net10.0` + `net10.0-windows`).
+- **Per-project `README.md`** for `Core/`, `Infrastructure.Persistence/`,
+  `Infrastructure.Protocol/`, `Services/`, `GUI.Windows/`, `Tests/`.
+- **`Docs/PREPROCESSOR_DIRECTIVES.md`** — historical map of the `#if` blocks that
+  used to drive the device variant.
+
+### Changed
+
+- **.NET 8 → .NET 10 migration** — TFM `net10.0-windows10.0.19041.0` for the
+  WinForms project, `net10.0` for the cross-platform projects.
+- `bitbucket-pipelines.yml` — image `sdk:10.0`, build via `.slnx`, added a `Test`
+  step after `Build`.
+- Renamed the WinForms project from `STEMPM` → `App` → `GUI.Windows`.
+- Migrated the solution file from `.sln` (legacy) to `.slnx` (modern XML, ~58%
+  fewer lines).
+- Build configurations reduced from 10 → 8 (removed `STEMDM`, `BUTTONPANEL`) and
+  finally to 2 (`Debug`, `Release`) once the runtime device-variant selection
+  landed.
+- `README.md` — multi-project structure, runtime device variant, single-file
+  publish recipe.
+- `Program.cs` — `IConfiguration` (`appsettings.json` + env vars) and
+  `AddDictionaryProvider()` / `AddProtocolInfrastructure()` /
+  `AddServices(config)`.
+- Namespaces `App.Core.*` → `Core.*` for the models / interfaces moved to `Core/`.
+
+### Removed
+
+- **Legacy `Boot_Interface_Tab`** (`Boot_WF_Tab.cs`) and its 3 null-arg DI tests;
+  `Spark_FirmwareUpdate_WF_Tab` is the canonical bootloader UI. Closes #78,
+  closes #57.
+- **`STEMDM` build configuration** — never used, no `#if STEMDM` in code.
+- **`BUTTONPANEL` build configuration** and the entire ButtonPanel module —
+  removed in 6 phases (test suite, Form1 wiring, MVP services / presenter / view,
+  core models, build config, resources). 27 files deleted, 142 tests removed,
+  ~1500 LOC dropped.
+- **`ExcelHandler.cs`** — replaced by
+  `Infrastructure.Persistence.ExcelDictionaryProvider`.
+- **`Stem.Device.Manager.sln`** — replaced by `.slnx`.
+- **`STEMProtocol/`** legacy folder (Phase 4) — ~2590 LOC removed once tabs were
+  switched to `ConnectionManager` / `ProtocolService`.
+- **All `#if TOPLIFT/EDEN/EGICON` blocks** — runtime selection via
+  `IDeviceVariantConfig`.
+
+### Fixed
+
+- **spec-001 / issue #74 — `SparkBatchUpdateService` end-of-batch restart only.**
+  `RESTART_MACHINE` (CMD `0x000A`) used to fire once per area in a multi-area
+  batch, but the SPARK firmware shuts the device down on restart, preventing
+  areas 2..N from running. Per STEM firmware-team confirmation (2026-04-27),
+  `RESTART_MACHINE` is hoisted out of `RunAreaAsync` and fires exactly once at
+  the end of the batch, addressed to the HMI board recipient (`0x000702C1`). On
+  the abort path no restart fires — recovery from a half-flashed device is
+  operator-driven. The single-file `IBootService.StartFirmwareUploadAsync` is
+  unchanged. Tests + `Docs/PROTOCOL.md` §8 +
+  `specs/001-spark-ble-fw-stabilize/data-model.md` updated to reflect the batch
+  composition.
+- `#if BUTTONPANEL` blocks removed from `Form1.cs` (~lines 156, 344) and
+  `SplashScreen.cs` (~line 12).
+- `ExcelHandler` decoupled from `Form1`: no more direct calls to
+  `hExcel.EstraiDizionario()`.
+
+### Removal statistics (cumulative across the modernization wave)
+
+- Files deleted: 27 (19 ButtonPanel + 8 ExcelHandler-related) + the legacy
+  `STEMProtocol/` folder.
+- Tests removed: 142 (34 ButtonPanel + 8 ExcelHandler).
+- LOC removed: ~1500 (legacy modules) + ~2590 (`STEMProtocol/`).
+- Build configurations: 10 → 8 → 2.
 
 ---
 
 ## [0.2.15] - 2026-04-14
 
-Stato dell'arte del progetto legacy pre-modernizzazione. ~330 commit, ~56k LOC, 0 test automatizzati.
+State of the legacy project before the modernization wave. ~330 commits, ~56k LOC,
+0 automated tests.
 
-### Protocollo STEM
+### STEM protocol
 
-- Layer stack proprietario completo: Application Layer, Network Layer, Transport Layer, Protocol Manager
-- Supporto multi-canale: CAN (PCAN USB), BLE (Plugin.BLE), Seriale (System.IO.Ports)
-- `PacketManager` per gestione pacchetti multi-canale con ricomposizione chunk e eventi
-- Sniffer application layer per debug comunicazione
-- `SPRollingCode` per sicurezza rolling code
-- CAN baudrate selezionabile (100 kbps / 250 kbps)
+- Full proprietary stack: Application Layer, Network Layer, Transport Layer,
+  Protocol Manager.
+- Multi-channel support: CAN (PCAN USB), BLE (Plugin.BLE), Serial
+  (`System.IO.Ports`).
+- `PacketManager` for multi-channel packet handling with chunk reassembly and
+  events.
+- Application-layer sniffer for communication debug.
+- `SPRollingCode` for rolling-code security.
+- Selectable CAN baud rate (100 kbps / 250 kbps).
 
 ### Bootloader
 
-- `BootManager` classico: aggiornamento firmware via CAN/BLE/Serial con barra progresso
-- `Boot_Smart_Tab`: bootloader smart con gestione canale hardware dinamica
-- Supporto filtro numero pagina, invio blocchi da 1024 byte
-- Lettura tipo firmware da file per invio corretto alla scheda
-- Start/End procedure, restart machine, program block
+- Classic `BootManager`: firmware update over CAN/BLE/Serial with progress bar.
+- `Boot_Smart_Tab`: smart bootloader with dynamic HW channel handling.
+- Page-number filter, 1024-byte block transfer.
+- Reads firmware type from the file to send the correct one to the board.
+- Start / End procedure, restart machine, program block.
 
-### Telemetria
+### Telemetry
 
-- Telemetria lenta: lettura singole variabili via comando Read Variable (0x0001)
-- Telemetria veloce: configurazione (0x0015), start (0x0016), stop (0x0017), ricezione dati (0x0018)
-- Grafici in tempo reale con OxyPlot (zoom custom asse X)
-- Tab telemetria standard + tab telemetria TopLift dedicata (~42k LOC)
+- Slow telemetry: single-variable reads via Read Variable command (0x0001).
+- Fast telemetry: configure (0x0015), start (0x0016), stop (0x0017), data
+  receive (0x0018).
+- Real-time charts via OxyPlot (custom X-axis zoom).
+- Standard telemetry tab + dedicated TopLift telemetry tab (~42k LOC).
 
-### Dizionari Excel
+### Excel dictionaries
 
-- `ExcelHandler`: lettura dizionari da file Excel embedded (`Dizionari STEM.xlsx` ~187k)
-- Supporto stream-based (risorsa embedded via `MemoryStream`)
-- 3 tipi dati: `RowData` (indirizzi protocollo), `CommandData` (comandi), `VariableData` (variabili)
-- Lettura fogli: indirizzi macchina/scheda, lista comandi, dizionario variabili per device
+- `ExcelHandler`: reads dictionaries from an embedded Excel file
+  (`Dizionari STEM.xlsx`, ~187k).
+- Stream-based support (embedded resource via `MemoryStream`).
+- 3 data types: `RowData` (protocol addresses), `CommandData` (commands),
+  `VariableData` (variables).
+- Sheets: machine/board addresses, command list, per-device variable dictionary.
 
-### Test Pulsantiere (Banco Collaudo)
+### Button panel test (test bench)
 
-- Architettura pulita MVP: `IButtonPanelTestService` → `ButtonPanelTestPresenter` → `ButtonPanelTestTabControl`
-- Dependency Injection con `Microsoft.Extensions.DependencyInjection`
-- 4 tipi pulsantiera: DIS0023789, DIS0025205, DIS0026166, DIS0026182
-- 4 tipi collaudo: Completo, Pulsanti, LED, Buzzer
-- `ButtonPanel` factory method con maschere bit per ogni tipo
-- Test pulsanti: attesa pressione con timeout 10s, verifica maschera bit
-- Test LED: accensione verde/rosso con conferma operatore
-- Test buzzer: attivazione con conferma operatore
-- `CancellationToken` per interruzione collaudo
-- Download risultati collaudo
-- Indicatori visivi per stato pulsante (Idle, Waiting, Success, Failed)
-- Messaggi colorati in RichTextBox per feedback visivo
-- Gestione errori in vista, presenter e servizio (PR #9)
+- Clean MVP architecture: `IButtonPanelTestService` →
+  `ButtonPanelTestPresenter` → `ButtonPanelTestTabControl`.
+- Dependency injection via `Microsoft.Extensions.DependencyInjection`.
+- 4 panel types: DIS0023789, DIS0025205, DIS0026166, DIS0026182.
+- 4 test types: full, buttons, LEDs, buzzer.
+- `ButtonPanel` factory method with bit masks per panel type.
+- Button test: wait-press with 10s timeout, bit-mask check.
+- LED test: green / red on with operator confirm.
+- Buzzer test: activation with operator confirm.
+- `CancellationToken` for test interruption.
+- Download of test results.
+- Visual indicators per button (Idle, Waiting, Success, Failed).
+- Colored RichTextBox messages for visual feedback.
+- Error handling in view, presenter and service (PR #9).
 
-### Code Generator
+### Code generator
 
-- `SP_Code_Generator`: generazione file `sp_config.h` con configurazioni protocollo
-- Lista configurazioni: CAN channels, serial buffers, router, device table, logs, ecc.
+- `SP_Code_Generator`: generates `sp_config.h` with protocol configuration
+  values (CAN channels, serial buffers, router, device table, logs, …).
 
 ### GUI (Windows Forms)
 
-- Form principale con TabControl multi-pagina
-- Tab BLE Scanner con scansione dispositivi e connessione
-- Tab CAN con gestione TX/RX e stato connessione PCAN
-- Tab Bootloader (classico + smart)
-- Tab Telemetria (standard + TopLift dedicata)
-- Tab Test Pulsantiere (MVP)
-- SplashScreen all'avvio
-- Barra di stato con stato connessione PCAN
-- 10 build configurations: Debug, Release, TOPLIFT-A2-Debug/Release, EDEN-Debug/Release, EGICON-Debug/Release, STEMDM, BUTTONPANEL
-- Configurazioni device via `#if` preprocessor (TOPLIFT, EDEN, EGICON, BUTTONPANEL)
-- Titolo form dinamico per configurazione
-- Selezione canale comunicazione CAN/BLE/Serial via menu
-- Dimensione minima form impostata
-- Logger basico (`Terminal`) con StringBuilder
+- Main form with multi-page TabControl.
+- BLE Scanner tab (device scan + connect).
+- CAN tab (TX/RX, PCAN connection state).
+- Bootloader tab (classic + smart).
+- Telemetry tab (standard + dedicated TopLift).
+- Button panel test tab (MVP).
+- SplashScreen at startup.
+- Status bar with PCAN connection state.
+- 10 build configurations: Debug, Release, TOPLIFT-A2-Debug/Release,
+  EDEN-Debug/Release, EGICON-Debug/Release, STEMDM, BUTTONPANEL.
+- Device-variant configuration via `#if` preprocessor (TOPLIFT, EDEN, EGICON,
+  BUTTONPANEL).
+- Dynamic form title per configuration.
+- Communication channel selection (CAN/BLE/Serial) via menu.
+- Minimum form size set.
+- Basic logger (`Terminal`) backed by `StringBuilder`.
 
-### Utilità
+### Utilities
 
-- `CircularProgressBar`: custom control per barra progresso circolare
-- `SerialPortManager`: scansione e gestione porte seriali
-- `PCAN_Manager`: gestione hardware PCAN USB
-- `BLE_Manager`: gestione Bluetooth Low Energy (escluso da compilazione)
+- `CircularProgressBar`: custom control for a circular progress bar.
+- `SerialPortManager`: serial port scan and management.
+- `PCAN_Manager`: PCAN USB hardware management.
+- `BLE_Manager`: Bluetooth Low Energy management (excluded from compilation in
+  some configs).
 
-### Dipendenze
+### Dependencies
 
-- ClosedXML 0.105.0, DocumentFormat.OpenXml 3.5.1 (Excel)
-- OxyPlot.WindowsForms 2.2.0 (grafici)
-- Peak.PCANBasic.NET 5.0.1 (CAN)
-- Plugin.BLE 3.2.0 (Bluetooth)
-- System.IO.Ports 10.0.5 (seriale)
-- Microsoft.Extensions.DependencyInjection 10.0.5
-- Microsoft.Windows.SDK.BuildTools 10.0.28000.1721
+- ClosedXML 0.105.0, DocumentFormat.OpenXml 3.5.1 (Excel).
+- OxyPlot.WindowsForms 2.2.0 (charts).
+- Peak.PCANBasic.NET 5.0.1 (CAN).
+- Plugin.BLE 3.2.0 (Bluetooth).
+- System.IO.Ports 10.0.5 (serial).
+- Microsoft.Extensions.DependencyInjection 10.0.5.
+- Microsoft.Windows.SDK.BuildTools 10.0.28000.1721.
 
-### Note
+### Notes
 
-- Progetto monolitico: singolo `App.csproj` (ex `STEMPM.csproj`), nessuna separazione in librerie
-- `Form1.cs` è un God Object (~55k LOC con Designer) — contiene GUI + logica protocollo + telemetria
-- 0 test automatizzati
-- 0 documentazione formale (README vuoti fino a v2.15)
-- Target: `net8.0-windows10.0.19041.0`, `win-x64`
-- Autore originale: Michele Pignedoli
-- Modernizzazione iniziata da: Luca Veronelli (branch `test/copertura-iniziale`)
+- Monolithic project: a single `App.csproj` (formerly `STEMPM.csproj`), no
+  separation into libraries.
+- `Form1.cs` is a God Object (~55k LOC including the Designer file) — GUI +
+  protocol logic + telemetry mixed together.
+- 0 automated tests.
+- 0 formal documentation (READMEs empty up to v2.15).
+- Target: `net8.0-windows10.0.19041.0`, `win-x64`.
+- Original author: Michele Pignedoli.
+- Modernization started by: Luca Veronelli (branch `test/copertura-iniziale`).
 
 ---
 
-## Storico Versioni Precedenti (da commit messages)
+## Earlier version history (from commit messages)
 
-| Versione | SemVer | Milestone |
-|----------|--------|-----------|
-| 1.0 | 0.1.0 | Protocollo STEM impacchettato, sniffer completato |
-| 1.1 | 0.1.1 | Riordino per gestione risposte |
-| 1.2 | 0.1.2 | Primo bootloader funzionante |
-| 1.3 | 0.1.3 | Fix pack ID, accelerazione boot |
-| 1.4 | 0.1.4 | Aggiornamento scheda madre TopLift |
-| 1.5 | 0.1.5 | Gestione tastiere + accelerazione boot |
-| 1.6 | 0.1.6 | Risposta pacchetti funzionante |
-| 1.7 | 0.1.7 | Filtro pagina bootloader |
-| 1.8 | 0.1.8 | Barra stato connessione PCAN, dizionario variabili logiche |
-| 2.1 | 0.2.1 | Telemetria funzionante |
+| Version | SemVer | Milestone |
+|---------|--------|-----------|
+| 1.0 | 0.1.0 | STEM protocol packaged, sniffer completed |
+| 1.1 | 0.1.1 | Reorder for response handling |
+| 1.2 | 0.1.2 | First working bootloader |
+| 1.3 | 0.1.3 | Pack ID fix, faster boot |
+| 1.4 | 0.1.4 | TopLift mainboard update |
+| 1.5 | 0.1.5 | Keypad handling + faster boot |
+| 1.6 | 0.1.6 | Packet response working |
+| 1.7 | 0.1.7 | Bootloader page filter |
+| 1.8 | 0.1.8 | PCAN connection status bar, logical-variables dictionary |
+| 2.1 | 0.2.1 | Telemetry working |
 | 2.7 | 0.2.7 | BLE with/without response |
-| 2.8 | 0.2.8 | Lettura tipo firmware da file |
-| 2.10 | 0.2.10 | Semplificazione per distributori internazionali |
-| 2.11 | 0.2.11 | Versioni Complete/Spark/Eden/TopLiftA2, decodifica fault |
-| 2.14 | 0.2.14 | Seriale + CAN baudrate selezionabile (100/250 kbps) |
-| 2.15 | 0.2.15 | Fix telemetria lenta + attivazione telemetria veloce |
+| 2.8 | 0.2.8 | Read firmware type from file |
+| 2.10 | 0.2.10 | Simplification for international distributors |
+| 2.11 | 0.2.11 | Complete/Spark/Eden/TopLiftA2 variants, fault decoding |
+| 2.14 | 0.2.14 | Serial + selectable CAN baud rate (100/250 kbps) |
+| 2.15 | 0.2.15 | Slow-telemetry fix + fast-telemetry activation |
 
 ---
 
-## Storico URL versioni
+## Version URLs
 
-[Unreleased]: https://bitbucket.org/stem-fw/stem-device-manager/branches
+[Unreleased]: https://github.com/luca-veronelli-stem/stem-device-manager/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/luca-veronelli-stem/stem-device-manager/releases/tag/v0.3.0
+[0.2.15]: https://bitbucket.org/stem-fw/stem-device-manager/src/80bf9c6/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,14 +1,14 @@
 <Project>
   <PropertyGroup>
-	<!-- Versione centralizzata -->
-	<Version>0.2.15</Version>
-	<FileVersion>0.2.15.0</FileVersion>
-	<AssemblyVersion>0.2.15.0</AssemblyVersion>
+	<!-- Centralized version -->
+	<Version>0.3.0</Version>
+	<FileVersion>0.3.0.0</FileVersion>
+	<AssemblyVersion>0.3.0.0</AssemblyVersion>
 
-	<!-- Metadati autore/azienda -->
+	<!-- Author / company metadata -->
 	<Authors>Michele Pignedoli, Luca Veronelli</Authors>
 	<Company>STEM E.m.s.</Company>
-	<Copyright>Copyright © 2025-2026 STEM E.m.s. Tutti i diritti riservati.</Copyright>
+	<Copyright>Copyright © 2025-2026 STEM E.m.s. All rights reserved.</Copyright>
 
 	<!-- Build settings comuni -->
 	<Nullable>enable</Nullable>

--- a/Docs/SHIPPED_README.txt
+++ b/Docs/SHIPPED_README.txt
@@ -1,0 +1,189 @@
+================================================================================
+					   STEM DEVICE MANAGER v0.3.0
+							  STEM E.m.s.
+================================================================================
+
+DESCRIZIONE
+-----------
+Applicazione desktop per la gestione, diagnostica e comunicazione con i
+dispositivi STEM tramite il protocollo proprietario multi-canale (CAN, BLE,
+Seriale).
+
+Funzioni principali:
+- Comunicazione CAN (PCAN USB), BLE e Seriale
+- Lettura/scrittura variabili e comandi via dizionari (API Azure + fallback Excel)
+- Aggiornamento firmware (bootloader classico + batch SPARK)
+- Telemetria in tempo reale (lenta + veloce) con grafici
+- Generatore di codice (sp_config.h)
+
+
+REQUISITI
+---------
+- Windows 10/11 (64-bit)
+- PCAN USB (opzionale, solo per comunicazione CAN; richiede driver Peak)
+- Bluetooth 4.0+ (opzionale, solo per BLE)
+- Nessuna installazione richiesta (eseguibile self-contained)
+
+
+AVVIO
+-----
+Doppio click su: GUI.Windows.exe
+
+NOTA: al primo avvio Windows SmartScreen potrebbe segnalare l'eseguibile
+come "non riconosciuto". Cliccare "Ulteriori informazioni" -> "Esegui comunque".
+
+
+================================================================================
+						SELEZIONE VARIANTE DISPOSITIVO
+================================================================================
+
+A partire dalla v0.3.0 la variante (TopLift / Eden / Egicon-SPARK / Generic)
+si seleziona a runtime, senza ricompilare.
+
+VARIANTI SUPPORTATE:
+--------------------
+- Generic    (default - tutti i dispositivi STEM standard)
+- TopLift    (TopLift A2 - canale di default: CAN)
+- Eden       (Eden XP)
+- Egicon     (SPARK / Egicon - update firmware in batch via BLE)
+
+PROCEDURA:
+1. Aprire Windows PowerShell ed eseguire UNO dei comandi seguenti:
+		[Environment]::SetEnvironmentVariable("Device__Variant", "TopLift", "User")
+		[Environment]::SetEnvironmentVariable("Device__Variant", "Eden", "User")
+		[Environment]::SetEnvironmentVariable("Device__Variant", "Egicon", "User")
+		[Environment]::SetEnvironmentVariable("Device__Variant", "Generic", "User")
+
+   In alternativa da Prompt dei comandi:
+		setx Device__Variant "TopLift"
+
+2. Chiudere e riaprire l'applicazione per applicare le modifiche.
+
+3. La variante attiva e' visibile nel titolo della finestra principale.
+
+NOTA: il doppio underscore "__" separa la sezione dalla chiave (sintassi
+.NET Configuration). Se la variabile non e' impostata o contiene un valore
+non valido, viene usata la variante "Generic".
+
+
+================================================================================
+					   CONFIGURAZIONE API DIZIONARI (AZURE)
+================================================================================
+
+L'applicazione scarica i dizionari di comandi/variabili dall'API Azure
+"Stem.Dictionaries.Manager". I valori di default sono gia' inclusi e
+funzionano senza configurazione aggiuntiva (la chiave di test e' embedded).
+
+Per sovrascrivere la configurazione (chiave personale, endpoint diverso,
+timeout piu' alto) impostare le seguenti variabili d'ambiente:
+
+VARIABILI OPZIONALI:
+--------------------
+1. DictionaryApi__ApiKey
+   Chiave API per l'autenticazione. Se non configurata viene usata quella
+   di default embedded nel file appsettings.json.
+
+2. DictionaryApi__BaseUrl
+   URL base dell'API (default:
+   https://app-dictionaries-manager-prod.azurewebsites.net/).
+
+3. DictionaryApi__TimeoutSeconds
+   Timeout in secondi per le chiamate HTTP (default: 30).
+
+4. Device__SenderId
+   Indirizzo STEM del mittente (default: 8). Cambiarlo solo se richiesto
+   esplicitamente dal supporto.
+
+PROCEDURA:
+1. Richiedere la chiave API personale al contatto di supporto (se necessario).
+2. Aprire Windows PowerShell ed eseguire:
+		[Environment]::SetEnvironmentVariable("DictionaryApi__ApiKey", "<API_KEY>", "User")
+   Oppure da Prompt dei comandi:
+		setx DictionaryApi__ApiKey "<API_KEY>"
+3. Chiudere e riaprire l'applicazione.
+
+Nota: sostituire <API_KEY> con la chiave fornita.
+
+
+================================================================================
+						 USO OFFLINE
+================================================================================
+
+Se l'API Azure non e' raggiungibile (rete assente, chiave revocata, server
+down), l'applicazione passa automaticamente al dizionario Excel embedded:
+
+- I dizionari di comandi/variabili vengono letti dal file Excel incorporato
+  nell'eseguibile (nessun file esterno richiesto).
+- Tutte le funzionalita' di comunicazione (CAN/BLE/Serial), bootloader e
+  telemetria continuano a funzionare normalmente.
+- L'unica limitazione: i dizionari embedded potrebbero non includere le
+  variabili piu' recenti aggiunte sul portale Azure.
+
+Per forzare l'uso del fallback offline (debug): scollegare la rete o
+impostare DictionaryApi__BaseUrl ad un indirizzo non valido.
+
+
+================================================================================
+					   SELEZIONE CANALE DI COMUNICAZIONE
+================================================================================
+
+Il canale (CAN / BLE / Seriale) si seleziona dal menu dell'applicazione.
+Il canale di default dipende dalla variante:
+
+- TopLift  -> CAN
+- Generic / Eden / Egicon -> BLE
+
+Per CAN: collegare il dongle PCAN USB e installare i driver Peak.
+Per BLE: assicurarsi che il Bluetooth di Windows sia attivo.
+Per Seriale: collegare il dispositivo via USB-Serial e selezionare la
+porta COM dal menu.
+
+
+================================================================================
+							  FUNZIONALITA'
+================================================================================
+
+- Connessione multi-canale CAN / BLE / Seriale con switch a runtime
+- Bootloader: aggiornamento firmware singolo + batch SPARK (multi-area)
+- Telemetria lenta (lettura on-demand) e veloce (streaming continuo)
+- Grafici telemetria in tempo reale (OxyPlot)
+- Generatore di codice sp_config.h
+- Dizionari aggiornati live dall'API Azure (con fallback Excel offline)
+- Selezione runtime della variante dispositivo
+
+
+================================================================================
+						   RISOLUZIONE PROBLEMI
+================================================================================
+
+PROBLEMA: l'app non parte / errore "MSVCP140.dll mancante"
+SOLUZIONE: installare il "Microsoft Visual C++ Redistributable x64".
+
+PROBLEMA: PCAN non rilevato
+SOLUZIONE: installare i driver Peak da www.peak-system.com, scollegare e
+ricollegare il dongle.
+
+PROBLEMA: BLE non trova il dispositivo
+SOLUZIONE: verificare che il Bluetooth di Windows sia attivo, riavviare
+l'adattatore Bluetooth, riavviare l'app.
+
+PROBLEMA: variante / chiave API impostate ma non applicate
+SOLUZIONE: chiudere COMPLETAMENTE l'app (anche dalla tray) e riavviarla.
+Le variabili d'ambiente vengono lette solo all'avvio.
+
+PROBLEMA: errore di download dizionari
+SOLUZIONE: l'app ricade automaticamente sul dizionario embedded; verificare
+in seguito la connettivita' di rete o la validita' della chiave API.
+
+
+================================================================================
+							   SUPPORTO
+================================================================================
+
+Per problemi o richieste: l.veronelli@stem.it
+
+
+================================================================================
+						 (c) 2026 STEM E.m.s.
+					  Tutti i diritti riservati
+================================================================================

--- a/GUI.Windows/Forms/Form1.cs
+++ b/GUI.Windows/Forms/Form1.cs
@@ -27,7 +27,7 @@ namespace StemPC
         private readonly BLEManager _bleManager;
         private readonly ILogger<Form1> _logger;
 
-        public const string Software_Version = "2.15";
+        public const string Software_Version = "0.3.0";
 
         // Canale hardware corrente selezionato. Le mutazioni vengono propagate a
         // ConnectionManager via SwitchToAsync.

--- a/GUI.Windows/GUI.Windows.csproj
+++ b/GUI.Windows/GUI.Windows.csproj
@@ -83,10 +83,27 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
+	<None Update="Properties\Settings.settings">
+	  <Generator>SettingsSingleFileGenerator</Generator>
+	  <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+	</None>
   </ItemGroup>
+
+  <!-- File da includere nella cartella di publish -->
+  <ItemGroup>
+	<None Include="..\Docs\SHIPPED_README.txt">
+	  <Link>README.txt</Link>
+	  <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+	</None>
+  </ItemGroup>
+
+  <!-- Copia e rinomina README durante build/publish -->
+  <Target Name="CopyReadmeToOutput" AfterTargets="Build">
+	<Copy SourceFiles="..\Docs\SHIPPED_README.txt" DestinationFiles="$(OutputPath)README.txt" />
+  </Target>
+
+  <Target Name="CopyReadmeToPublish" AfterTargets="Publish">
+	<Copy SourceFiles="..\Docs\SHIPPED_README.txt" DestinationFiles="$(PublishDir)README.txt" />
+  </Target>
 
 </Project>

--- a/GUI.Windows/Program.cs
+++ b/GUI.Windows/Program.cs
@@ -8,18 +8,22 @@ using Services;
 /// <summary>
 ///*****************************************************************************
 /// @file    Program.cs
-/// @author  Michele Pignedoli
-///@version  2.15
+/// @author  Michele Pignedoli, Luca Veronelli
+///@version  0.3.0
 /// @date    20/10/2025
 /// @brief   STEM Device Manager Main program body
 ///*****************************************************************************
 ///
-/// 2.10: + TopLift A2 and Eden XP activation
-/// 2.11: + Read firmware version activation for mainboard
-/// 2.14: + CAN baud rate variable
-///       + uart suport
-/// 2.15: + Fix telemetria lenta
-///       + attivazione telemetria veloce
+/// 2.10:  + TopLift A2 and Eden XP activation
+/// 2.11:  + Read firmware version activation for mainboard
+/// 2.14:  + CAN baud rate variable
+///        + uart support
+/// 2.15:  + Slow telemetry fix
+///        + fast telemetry activation
+/// 0.3.0: + SemVer reset, multi-project architecture, Azure dictionary API,
+///          ProtocolService/TelemetryService/BootService, ConnectionManager,
+///          DictionaryCache, removal of #if device variants (runtime selection),
+///          Spark BLE firmware stabilization (spec-001), Lean 4 invariants.
 ///
 /// TODO:
 /// - Completare decodifica faults

--- a/README.md
+++ b/README.md
@@ -1,167 +1,212 @@
-# Stem.Device.Manager
+﻿# Stem.Device.Manager
 
-[![Version](https://img.shields.io/badge/version-2.15-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.0-blue)](./CHANGELOG.md)
 [![.NET](https://img.shields.io/badge/.NET-10.0-512BD4)](https://dotnet.microsoft.com/)
-[![Tests](https://img.shields.io/badge/tests-274-brightgreen)](./Tests/)
-[![License](https://img.shields.io/badge/license-Proprietary-red)](#licenza)
+[![Tests](https://img.shields.io/badge/tests-292%20%2F%20470-brightgreen)](./Tests/)
+[![License](https://img.shields.io/badge/license-Proprietary-red)](#license)
 
-> **Applicativo desktop per la gestione, diagnostica e comunicazione dei dispositivi STEM via protocollo proprietario multi-canale (CAN, BLE, Serial).**  
-> **Ultimo aggiornamento:** 2026-04-20
-
----
-
-## Panoramica
-
-Stem Device Manager è un tool Windows desktop utilizzato per:
-
-- **Comunicare** con i dispositivi via protocollo proprietario (CAN, BLE, Serial)
-- **Leggere/scrivere** variabili e comandi tramite dizionari Azure API
-- **Aggiornare firmware** via bootloader proprietario (classico e smart)
-- **Monitorare telemetria** in tempo reale con grafici OxyPlot
-- **Generare codice** configurazione (`sp_config.h`)
-
-### Stato Attuale
-
-Il progetto è un **monolite legacy** in fase di modernizzazione incrementale:  
-- `Form1.cs` è un God Object (~54k LOC con Designer) — usa `IDictionaryProvider` per i dizionari  
-- **274 test automatizzati** (xUnit) — unit + integration, di cui 132 cross-platform (CI Linux)  
-- Architettura multi-progetto:
-  - **Core** (net10.0) — modelli dominio + interfacce  
-  - **Infrastructure.Persistence** (net10.0) — provider dati (API Azure + Excel + Fallback)  
-  - **Infrastructure.Protocol** (dual TFM) — adapter HW CAN/BLE/Serial + driver PCAN  
-  - **Services** (net10.0) — logica pura (PacketDecoder, DictionarySnapshot, ...)  
-  - **App** (net10.0-windows, WinForms) — entry point + GUI + legacy STEMProtocol  
-- Refactor architetturale (vedi [`Docs/REFACTOR_PLAN.md`](./Docs/REFACTOR_PLAN.md)):
-  - Fase 1 — protocol abstractions in Core ✅
-  - Fase 2 — services layer + HW adapter (Step 1-2 completati, in corso) 🚧
-  - Fase 3 — decomposizione Form1 ⏳
+> **Desktop application for managing, diagnosing and communicating with STEM devices over the proprietary multi-channel protocol (CAN, BLE, Serial).**
+> **Last updated:** 2026-04-29
 
 ---
 
-## Caratteristiche
+## Overview
 
-| Feature | Stato | Descrizione |
-|---------|-------|-------------|
-| **Protocollo STEM** | ✅ | Layer stack proprietario (Application, Network, Transport) |
-| **CAN (PCAN)** | ✅ | Comunicazione via Peak PCAN USB |
+Stem Device Manager is a Windows desktop tool used to:
+
+- **Communicate** with STEM devices via the proprietary protocol (CAN, BLE, Serial).
+- **Read / write** variables and commands using dictionaries served by the Azure REST API (with embedded Excel fallback).
+- **Update firmware** via the proprietary bootloader (classic + Spark batch).
+- **Monitor telemetry** in real time with OxyPlot charts (slow + fast streams).
+- **Generate code** for protocol configuration (`sp_config.h`).
+
+### Current state
+
+The codebase is being modernized incrementally. Phases 1–4 of the refactor are complete:
+
+- `Form1.cs` has been reduced to a thin shell (~731 LOC) on top of `ConnectionManager` + `DictionaryCache`.
+- **292 cross-platform tests** + **470 Windows-only tests** (xUnit).
+- Multi-project layout:
+  - **Core** (`net10.0`) — domain models + interfaces.
+  - **Infrastructure.Persistence** (`net10.0`) — dictionary providers (Azure API + Excel + Fallback).
+  - **Infrastructure.Protocol** (dual TFM) — HW adapters for CAN/BLE/Serial + legacy drivers.
+  - **Services** (`net10.0`) — pure logic (`ProtocolService`, `TelemetryService`, `BootService`, `ConnectionManager`, `DictionaryCache`).
+  - **GUI.Windows** (`net10.0-windows`, WinForms) — entry point + GUI.
+- Architectural roadmap in [`Docs/REFACTOR_PLAN.md`](./Docs/REFACTOR_PLAN.md):
+  - Phase 1 — protocol abstractions in Core ✅
+  - Phase 2 — services layer + HW adapters ✅
+  - Phase 3 — Form1 decomposition ✅
+  - Phase 4 — switch to the new stack, removal of legacy `STEMProtocol/` ✅
+  - Phase 5 — migration to the `Stem.Communication` NuGet (when available) ⏳
+
+---
+
+## Features
+
+| Feature | Status | Description |
+|---------|--------|-------------|
+| **STEM protocol** | ✅ | Proprietary stack (Application, Network, Transport) |
+| **CAN (PCAN)** | ✅ | Communication via Peak PCAN USB |
 | **BLE** | ✅ | Bluetooth Low Energy via Plugin.BLE |
-| **Seriale** | ✅ | Comunicazione via porta COM |
-| **Dizionari Azure API** | ✅ | Provider API REST con fallback Excel (DI) |
-| **Bootloader** | ✅ | Aggiornamento firmware (classico + smart) |
-| **Telemetria** | ✅ | Lettura variabili + grafici OxyPlot (lenta + veloce) |
-| **Code Generator** | ✅ | Genera sp_config.h |
-| **Test Automatizzati** | ✅ | 274 test (unit + integration) — xUnit |
+| **Serial** | ✅ | Communication over a COM port |
+| **Azure dictionary API** | ✅ | REST provider with embedded Excel fallback (DI) |
+| **Bootloader** | ✅ | Firmware update (classic + Spark batch) |
+| **Telemetry** | ✅ | Variable reads + OxyPlot charts (slow + fast) |
+| **Code generator** | ✅ | Generates `sp_config.h` |
+| **Automated tests** | ✅ | 292 cross-platform + 470 Windows (xUnit) |
 
 ---
 
-## Requisiti
+## Requirements
 
-- **.NET 10.0** (Windows 10+ x64)
-- **Visual Studio 2022/2026** con workload Desktop Development
-- **PCAN USB** (opzionale, per comunicazione CAN)
+- **.NET 10.0** (Windows 10+ x64).
+- **Visual Studio 2022/2026** with the *Desktop development with .NET* workload.
+- **PCAN USB** (optional, only required for CAN communication).
 
-### Dipendenze
+### Dependencies
 
-| Package | Versione | Uso |
-|---------|----------|-----|
-| ClosedXML | 0.105.0 | Lettura dizionari Excel (Infrastructure) |
-| DocumentFormat.OpenXml | 3.5.1 | Supporto formati Excel |
-| OxyPlot.WindowsForms | 2.2.0 | Grafici telemetria |
-| Peak.PCANBasic.NET | 5.0.1 | Interfaccia CAN PCAN |
+| Package | Version | Use |
+|---------|---------|-----|
+| ClosedXML | 0.105.0 | Excel dictionary reader (Infrastructure.Persistence) |
+| DocumentFormat.OpenXml | 3.5.1 | Excel format support |
+| OxyPlot.WindowsForms | 2.2.0 | Telemetry charts |
+| Peak.PCANBasic.NET | 5.0.1 | PCAN CAN interface |
 | Plugin.BLE | 3.2.0 | Bluetooth Low Energy |
-| System.IO.Ports | 10.0.5 | Comunicazione seriale |
+| System.IO.Ports | 10.0.5 | Serial communication |
 | Microsoft.Extensions.DependencyInjection | 10.0.5 | DI container |
 
 ---
 
 ## Quick Start
 
-```bash
-# Clona il repository
+```powershell
+# Clone
 git clone https://bitbucket.org/stem-fw/stem-device-manager
 
 # Build
-dotnet build
+dotnet build Stem.Device.Manager.slnx
 
-# Test
-dotnet test Tests/Tests.csproj
+# Test (cross-platform only — matches CI)
+dotnet test Tests/Tests.csproj --framework net10.0
 
-# Esegui
+# Run
 dotnet run --project GUI.Windows/GUI.Windows.csproj
 ```
 
-### Build Configurations
+### Build configurations
 
-| Configurazione | Descrizione |
-|----------------|-------------|
-| `Debug` | Default, tutte le feature |
-| `Release` | Build di rilascio |
-| `TOPLIFT-A2-Debug/Release` | Solo funzionalità TopLift A2 |
-| `EDEN-Debug/Release` | Solo funzionalità Eden XP |
-| `EGICON-Debug/Release` | Solo funzionalità Spark |
+Two configurations: `Debug` and `Release`. The device variant (TopLift / Eden / Egicon / Generic) is selected at runtime via `Device:Variant` in [`GUI.Windows/appsettings.json`](./GUI.Windows/appsettings.json) — the historical `#if TOPLIFT/EDEN/EGICON` blocks were removed in Phase 3.
+
+### Single-file publish (field-test executable)
+
+For field tests, publish a self-contained single-file executable that bundles the embedded Excel fallback dictionary (no external files required):
+
+```powershell
+dotnet publish GUI.Windows/GUI.Windows.csproj `
+    -c Release `
+    -r win-x64 `
+    --self-contained true `
+    -p:PublishSingleFile=true `
+    -p:IncludeNativeLibrariesForSelfExtract=true `
+    -p:EnableCompressionInSingleFile=true `
+    -o publish/v0.3.0
+```
+
+The Excel dictionary (`Resources/Dizionari STEM.xlsx`) is already an embedded resource, so the fallback works without shipping a separate file. `appsettings.json` is the only loose file copied next to the `.exe`; if you want it embedded too, set `Device:Variant` and `DictionaryApi:*` via environment variables (see [Configuration](#configuration)) and remove the `appsettings.json` from the publish folder.
 
 ---
 
-## Struttura Soluzione
+## Configuration
+
+`GUI.Windows/appsettings.json` (committed defaults):
+
+```json
+{
+  "DictionaryApi": {
+    "BaseUrl": "https://app-dictionaries-manager-prod.azurewebsites.net/",
+    "ApiKey": "<api-key>",
+    "TimeoutSeconds": 30
+  },
+  "Device": {
+    "Variant": "Generic",
+    "SenderId": 8
+  }
+}
+```
+
+Any value can be overridden at runtime via environment variables (use `__` for the section separator):
+
+```powershell
+$env:DictionaryApi__ApiKey   = "<api-key>"
+$env:DictionaryApi__BaseUrl  = "https://..."
+$env:Device__Variant         = "TopLift"
+```
+
+### Security note (v0.3.0 field test)
+
+- The Azure dictionary API requires an API key. v0.3.0 ships with the test key in `appsettings.json` to keep the field-test loop fast.
+- Risk is low: the API only serves dictionaries (commands / addresses / variables) — no device control, no PII.
+- Mitigations applied for the field test:
+  1. Single-file publish bundles `appsettings.json` next to the `.exe` — no separate config file to leak in transit.
+  2. The Excel fallback works offline: a temporary key revocation does not brick the tool.
+  3. The key can be overridden at runtime via the `DictionaryApi__ApiKey` env var, so each technician's machine can be moved to a per-user key without rebuilding.
+- Before v1.0: rotate the key, remove it from `appsettings.json`, require it from `DPAPI`-encrypted user secrets or Windows Credential Manager (`CredRead`/`CredWrite`).
+
+---
+
+## Solution Structure
 
 ```
 Stem.Device.Manager/
-├── Stem.Device.Manager.slnx          Solution file (XML moderno)
-├── Core/                             Modelli dominio + interfacce (net10.0, zero deps)
-│   ├── Models/                       Dizionario + protocol abstractions
-│   │                                 (Variable, Command, ProtocolAddress, DictionaryData,
-│   │                                  ConnectionState, DeviceVariant, DeviceVariantConfig,
-│   │                                  RawPacket, AppLayerDecodedEvent, TelemetryDataPoint)
-│   └── Interfaces/                   IDictionaryProvider, ICommunicationPort, IPacketDecoder,
-│                                     ITelemetryService, IBootService, IDeviceVariantConfig
-├── Infrastructure.Persistence/       Provider dati dizionario (net10.0)
-│   ├── Api/                          DictionaryApiProvider + DTO (REST Azure)
-│   ├── Excel/                        ExcelDictionaryProvider (fallback embedded)
-│   ├── FallbackDictionaryProvider    Decorator API→Excel
-│   └── DependencyInjection.cs        AddDictionaryProvider()
-├── Infrastructure.Protocol/          Adapter HW (dual TFM: net10.0 + net10.0-windows)
-│   └── Hardware/                     CanPort, BlePort, SerialPort (ICommunicationPort)
-│                                     + PCANManager driver + IPcanDriver/IBleDriver/ISerialDriver
-├── Services/                         Logica applicativa pura (net10.0 — cross-platform)
-│   └── Protocol/                     PacketDecoder, DictionarySnapshot
-├── GUI.Windows/                              Windows Forms (net10.0-windows)
-│   ├── Program.cs                    Entry point + DI + IConfiguration
-│   ├── Form1.cs                      Main form (God Object ~54k LOC)
-│   ├── STEMProtocol/                 Protocollo legacy (da migrare in Fase 4)
-│   ├── BLE_Manager.cs                Driver BLE (implementa IBleDriver)
-│   ├── SerialPort_Manager.cs         Driver seriale (implementa ISerialDriver)
-│   └── GUI/                          Tab pages WinForms
-├── Specs/                            Formalizzazioni Lean 4
-│   └── Phase1/                       Tipi/interfacce protocol (Fase 1)
-├── Tests/                            274 test (xUnit, dual TFM)
-│   ├── Unit/                         Core, Infrastructure.Persistence, Infrastructure.Protocol, Services, Terminal
-│   └── Integration/                  DI, ExcelHandler, CodeGenerator, Form1
-└── Docs/                             REFACTOR_PLAN, PROTOCOL, PREPROCESSOR_DIRECTIVES, Standards
+├── Stem.Device.Manager.slnx              Solution file (modern XML)
+├── Directory.Build.props                 Centralized version + author metadata
+├── Core/                                 Domain models + interfaces (net10.0, zero deps)
+├── Infrastructure.Persistence/           Dictionary providers (net10.0)
+│   ├── Api/                              DictionaryApiProvider + DTOs (Azure REST)
+│   ├── Excel/                            ExcelDictionaryProvider (embedded fallback)
+│   ├── FallbackDictionaryProvider        API → Excel decorator
+│   └── DependencyInjection.cs            AddDictionaryProvider()
+├── Infrastructure.Protocol/              HW adapters (dual TFM)
+│   ├── Hardware/                         CanPort, BlePort, SerialPort + driver abstractions
+│   └── Legacy/                           BLEManager, SerialPortManager (Windows-only)
+├── Services/                             Pure cross-platform logic (net10.0)
+│   ├── Protocol/                         ProtocolService, PacketDecoder, DictionarySnapshot
+│   ├── Telemetry/                        TelemetryService
+│   ├── Boot/                             BootService, SparkBatchUpdateService
+│   └── Cache/                            DictionaryCache, ConnectionManager
+├── GUI.Windows/                          Windows Forms entry point (net10.0-windows)
+│   ├── Program.cs                        DI + IConfiguration
+│   ├── Forms/Form1.cs                    Main form (thin shell)
+│   ├── Tabs/                             WinForms tab pages
+│   └── Resources/                        Icons + embedded Excel dictionary
+├── Lean/Spec001/                         Lean 4 invariants for Spark BLE stabilization
+├── Tests/                                xUnit, dual TFM (292 / 470)
+└── Docs/                                 REFACTOR_PLAN, PROTOCOL, Standards
 ```
 
 ---
 
-## Documentazione
+## Documentation
 
-- [App — Progetto principale](./GUI.Windows/README.md)
-- [Core — Modelli dominio e interfacce](./Core/README.md)
-- [Infrastructure.Persistence — Provider dati dizionario (API + Excel)](./Infrastructure.Persistence/README.md)
-- [Infrastructure.Protocol — Adapter HW CAN/BLE/Serial](./Infrastructure.Protocol/README.md)
-- [Services — Logica applicativa pura](./Services/README.md)
-- [Tests — Test automatizzati](./Tests/README.md)
-- [Standards e Templates](./Docs/Standards/)
-- [Piano di refactoring architetturale](./Docs/REFACTOR_PLAN.md)
-- [Protocollo STEM — funzionamento interno](./Docs/PROTOCOL.md)
-- [Direttive preprocessore (#if)](./Docs/PREPROCESSOR_DIRECTIVES.md)
-- [Lean/Spec001 — formalizzazioni Lean 4](./Lean/Spec001/)
+- [GUI.Windows — main project](./GUI.Windows/README.md)
+- [Core — domain models and interfaces](./Core/README.md)
+- [Infrastructure.Persistence — dictionary providers (API + Excel)](./Infrastructure.Persistence/README.md)
+- [Infrastructure.Protocol — HW adapters CAN/BLE/Serial](./Infrastructure.Protocol/README.md)
+- [Services — pure application logic](./Services/README.md)
+- [Tests — automated tests](./Tests/README.md)
+- [Standards & templates](./Docs/Standards/)
+- [Architectural refactoring plan](./Docs/REFACTOR_PLAN.md)
+- [STEM protocol — internal workings](./Docs/PROTOCOL.md)
+- [Preprocessor directives — historical map](./Docs/PREPROCESSOR_DIRECTIVES.md)
+- [Lean/Spec001 — Lean 4 formalizations](./Lean/Spec001/)
 - [CHANGELOG](./CHANGELOG.md)
 - [LICENSE](./LICENSE)
 
 ---
 
-## Licenza
+## License
 
-- **Proprietario:** STEM E.m.s.
-- **Autore:** Michele Pignedoli, Luca Veronelli
-- **Data di Creazione:** 2024-06-27
-- **Licenza:** Proprietaria - Tutti i diritti riservati
+- **Owner:** STEM E.m.s.
+- **Authors:** Michele Pignedoli, Luca Veronelli
+- **Creation date:** 2024-06-27
+- **License:** Proprietary — All rights reserved

--- a/Stem.Device.Manager.slnx
+++ b/Stem.Device.Manager.slnx
@@ -1,23 +1,9 @@
 <Solution>
-  <Configurations>
-    <BuildType Name="Debug" />
-    <BuildType Name="Release" />
-  </Configurations>
-  <Folder Name="/.copilot/">
-    <File Path=".copilot/copilot-instructions.md" />
-    <File Path=".copilot/sample-instructions.md" />
-  </Folder>
-  <Folder Name="/.copilot/agents/">
-    <File Path=".copilot/agents/coding-agent.md" />
-    <File Path=".copilot/agents/docs-agent.md" />
-    <File Path=".copilot/agents/formal-spec-agent.md" />
-    <File Path=".copilot/agents/issues-agent.md" />
-    <File Path=".copilot/agents/test-agent.md" />
-  </Folder>
   <Folder Name="/Docs/">
     <File Path="Docs/PREPROCESSOR_DIRECTIVES.md" />
     <File Path="Docs/PROTOCOL.md" />
     <File Path="Docs/REFACTOR_PLAN.md" />
+    <File Path="Docs/SHIPPED_README.txt" />
   </Folder>
   <Folder Name="/Docs/Standards/">
     <File Path="Docs/Standards/TEMPLATE_STANDARD.md" />
@@ -37,8 +23,8 @@
     <File Path="LICENSE" />
     <File Path="README.md" />
   </Folder>
-  <Project Path="GUI.Windows/GUI.Windows.csproj" />
   <Project Path="Core/Core.csproj" Id="3557f077-7abe-4f0b-a393-bfdca9acdf43" />
+  <Project Path="GUI.Windows/GUI.Windows.csproj" />
   <Project Path="Infrastructure.Persistence/Infrastructure.Persistence.csproj" Id="ef04ae12-ec87-4b4f-ba6a-206b085d18ba" />
   <Project Path="Infrastructure.Protocol/Infrastructure.Protocol.csproj" />
   <Project Path="Services/Services.csproj" Id="33cf0a23-a550-487b-a737-7c4c1c4e2d78" />


### PR DESCRIPTION
## Summary

Release v0.3.0: bumps versions across the solution, translates root docs to English, and adds a single Italian operator handout (`Docs/SHIPPED_README.txt`) that is copied next to the executable on build/publish.

## Changes

- `Directory.Build.props`, `GUI.Windows/Forms/Form1.cs`, `GUI.Windows/Program.cs`: bump version 0.2.15 → 0.3.0.
- `README.md`, `CHANGELOG.md`: rewritten in English; added single-file publish, runtime configuration, and security guidance.
- `Docs/SHIPPED_README.txt`: new Italian field-deployment guide (variant switching via `Device__Variant`, `DictionaryApi__*` env vars, offline fallback).
- `GUI.Windows/GUI.Windows.csproj`: copy `SHIPPED_README.txt` → `README.txt` in `$(OutputPath)` and `$(PublishDir)` via `AfterTargets="Build"`/`Publish"` targets.
- `Stem.Device.Manager.slnx`: register `Docs/SHIPPED_README.txt`.

## Design notes

- Historical v2.15 references in specs/tests are intentional baselines and left untouched.
- Italian is restricted to the shipped README only; all other release docs stay in English per repo policy.
- Single-file publish stays viable because the dictionary fallback is an embedded resource.

## Testing

- [x] `dotnet build -c Release` — green
- [x] `dotnet test Tests/Tests.csproj --framework net10.0` — 335/335 passed
