### PR TITLE
docs: seed Investigations/ notebook for #96 and #97

### DIFF
--- a/Docs/Investigations/senderid-endianness.md
+++ b/Docs/Investigations/senderid-endianness.md
@@ -1,0 +1,95 @@
+# Investigation — senderId byte order on the wire (RX may be inverted vs firmware)
+
+**Tracking issue:** [#97](https://github.com/luca-veronelli-stem/stem-device-manager/issues/97)
+**Started:** 2026-05-21
+**Status:** Hypothesis, not confirmed. Needs a real-device packet capture to clinch.
+
+---
+
+## Hypothesis
+
+`Services/Protocol/PacketDecoder.cs:119-125` reads the Transport-layer senderId as big-endian on the wire:
+
+```csharp
+private static uint ReadSenderIdBigEndian(ImmutableArray<byte> payload)
+{
+    return ((uint)payload[1] << 24)
+         | ((uint)payload[2] << 16)
+         | ((uint)payload[3] << 8)
+         | payload[4];
+}
+```
+
+v2.15 (`80bf9c6` — `STEMProtocol/STEM_protocol.cs:466`) reads the same bytes with the opposite shift order — i.e. **little-endian** on the wire:
+
+```csharp
+uint Source_Address = (TransportPacket[4] << 24)
+                    | (TransportPacket[3] << 16)
+                    | (TransportPacket[2] << 8)
+                    | TransportPacket[1];
+```
+
+The v2.15 receive path also looks the result up against the Excel `Dizionari STEM.xlsx` column G — verified in this investigation to contain **standard-form** addresses (`0x00080381`, `0x000A0441`, etc.), not byte-swapped ones. For v2.15 to have ever matched the dictionary against real device packets, `TransportPacket[1]` must be the LSB of the senderId on the wire, i.e. the firmware writes **little-endian**. The new code inverts that and computes the byte-swapped value (e.g. `0x81030800` for what should be `0x00080381`), so `DictionarySnapshot.FindSender` returns `null` and `AppLayerDecodedEvent.SenderDevice` / `SenderBoard` are empty strings.
+
+## Why the doc's historical explanation is suspect
+
+`Docs/PROTOCOL.md` §3.1 claims the legacy stack had byte-swapped addresses in the dictionary and the refactor "aligned the decoder to BE because the dictionary was migrated to the standard format." Two facts contradict the premise:
+
+1. The Excel `Dizionari STEM.xlsx` blob hash is identical between `80bf9c6` and HEAD (`8cedb73e398f7f4e25663384c462c5649e0c8c63`). The dictionary was never migrated.
+2. The Excel addresses at `80bf9c6` are already standard-form (`0x00080381`).
+
+So the legacy stack must have been reading LE on the wire to match standard addresses in the dict. The doc rewrite is part of the fix, not separate from it.
+
+## Why this is "investigation," not a one-line patch
+
+The "wrong" answer can be patched in one line:
+
+```csharp
+private static uint ReadSenderIdOnWire(ImmutableArray<byte> payload)
+{
+    return ((uint)payload[4] << 24)
+         | ((uint)payload[3] << 16)
+         | ((uint)payload[2] << 8)
+         | payload[1];
+}
+```
+
+But I don't have a real packet to verify the premise. The unit test `PacketDecoderTests.Decode_SenderIdRisolto_PopolaDeviceEBoard` is self-consistent (the test fixture writes BE, the decoder reads BE) and cannot catch this mismatch.
+
+## What's needed to clinch it
+
+Capture one raw RX frame from a known device (e.g. TopLift-A2 Madre `0x00080381`). Bytes `[1..4]` of the Transport-layer packet tell us the wire order directly:
+
+- Wire bytes `[0x81, 0x03, 0x08, 0x00]` → firmware emits LE → `PacketDecoder` is wrong.
+- Wire bytes `[0x00, 0x08, 0x03, 0x81]` → firmware emits BE → `PacketDecoder` is right, and empty sender names (if observed) have a different cause.
+
+Easiest capture path: temporary log line in `ProtocolService.OnPortPacketReceived` dumping `merged.Skip(1).Take(4)` as hex for the first few packets, then revert.
+
+## Scope of impact (if confirmed)
+
+- `AppLayerDecodedEvent.SenderDevice` / `SenderBoard` will be empty strings. UI shows the raw hex address as fallback. Display-only.
+- `AppLayerDecodedEvent.SenderId` (uint) is wrong by byte-swap. Any consumer that gates on it semantically is broken.
+- Does **not** break `CMD_READ_VARIABLE` resolution — that uses `[VariableHighIndex=9]`/`[VariableLowIndex=10]` (the AL payload's address pair), which is independent of the TP senderId.
+- Does **not** break TX — `ProtocolService.BuildTransportPacket` writes the PC's own senderId BE (unchanged from v2.15); the firmware does whatever it does with it.
+
+## Independent symptoms surfaced from the same code reading
+
+- `TelemetryService.UpdateSourceAddress` writes the *configured* source address BE into the telemetry-configure payload at `[11..14]` — both v2.15 and HEAD do this identically, so it's not a regression.
+- For BLE/Serial frames, the recipientId is written LE into bytes `[2..5]` of the wire frame — both versions do this identically too.
+
+## Not the cause of
+
+- The telemetry / read-reply data being silently dropped — that's the DataType vocabulary issue, see [#96](https://github.com/luca-veronelli-stem/stem-device-manager/issues/96).
+- The Boot Interface tab being missing — that's a UI removal, see [#95](https://github.com/luca-veronelli-stem/stem-device-manager/issues/95).
+
+## Next bench actions
+
+- [ ] Capture one TP-layer packet on bench, confirm wire byte order at offsets `[1..4]`.
+- [ ] If LE confirmed: rename `ReadSenderIdBigEndian` → `ReadSenderIdOnWire`, swap the shifts, update `Docs/PROTOCOL.md` §3.1 and the doc-comment in `PacketDecoder.cs` to match the corrected understanding.
+- [ ] Rewrite the unit test to assert against real captured wire bytes (or against the documented LE convention), not against a self-built fixture.
+
+## Changelog of this investigation
+
+| Date | Note |
+|---|---|
+| 2026-05-21 | Filed [#97](https://github.com/luca-veronelli-stem/stem-device-manager/issues/97); cross-checked legacy receive path + Excel column G; doc §3.1 narrative ruled out as accurate. |

--- a/Docs/Investigations/telemetry-datatype-vocabulary.md
+++ b/Docs/Investigations/telemetry-datatype-vocabulary.md
@@ -1,0 +1,74 @@
+# Investigation — telemetry / read-reply silently dropped (API DataType vocabulary mismatch)
+
+**Tracking issue:** [#96](https://github.com/luca-veronelli-stem/stem-device-manager/issues/96)
+**Started:** 2026-05-21
+**Status:** Hypothesis with mechanical proof from code reading + dictionary diff. Bench confirmation pending.
+
+---
+
+## Hypothesis
+
+`Services/Telemetry/TelemetryService.cs:411` only recognizes the Excel-style C type strings:
+
+```csharp
+private static int DataTypeWidth(string? dataType) => dataType?.Trim() switch
+{
+    "uint8_t" => 1,
+    "uint16_t" => 2,
+    "uint32_t" => 4,
+    _ => 0
+};
+```
+
+The Azure dictionary API (`stem-dictionaries-manager`) emits canonical .NET names instead:
+
+| address | API DataType | Excel DataType |
+|---|---|---|
+| `0x0000` | `UInt16` | `uint16_t ` |
+| `0x0003` | `UInt32` | `uint32_t ` |
+| `0x0006` | `Bitmapped[2]` | `due word uint16_t bitmapped` |
+| `0x8006` | `UInt8` | `uint8_t` |
+
+When the live dictionary comes from `DictionaryApiProvider` (the default — `GUI.Windows/appsettings.json` has both `BaseUrl` and `ApiKey` populated), every variable lookup hits the `_ => 0` branch, then:
+
+- `HandleReadReply` (line 326): `if (width == 0) return;` — every `CMD_READ_VARIABLE` reply silently dropped.
+- `EmitFastStreamDataPoints` (line 343): `if (width == 0) continue;` — every fast-stream variable skipped, no `DataReceived` events fire.
+
+End-to-end effect: user sees no telemetry values, no read-reply data, no error.
+
+## Why this regressed
+
+v2.15 (`80bf9c6`) read variables only from the Excel via `ExcelHandler`, which returned the C-style strings the legacy `TelemetryManager.cs:193-206` already handled. The refactor introduced `DictionaryApiProvider` and `FallbackDictionaryProvider`, defaulting to API-first, but did not align the type-name vocabulary the consumer expects.
+
+## Evidence collected so far
+
+- **2026-05-21** — API vs Excel diff on TopLift-A2 Madre (`0x00080381`): 32 of the common variables have mismatched DataType strings.
+- API endpoint queried: `GET /api/dictionaries/10/resolved` (TopLift-A2 Madre).
+- The DataType field is consumed only by `DataTypeWidth`. No other call site uses the string.
+
+## Open questions before patching
+
+1. **Where to normalize.**
+   - At the API boundary (`DictionaryApiProvider` maps API names → C-style names before producing `Variable`). Pro: keeps `Services/` ignorant of the API quirk. Con: hides the canonical names the rest of the .NET ecosystem expects.
+   - At the consumer (`DataTypeWidth` accepts both vocabularies). Pro: most local change. Con: every future width-aware call site must remember to accept both.
+   - Upstream (`stem-dictionaries-manager` emits C-style names natively). Pro: single source of truth. Con: breaks any other client already coded against the canonical names.
+2. **`Bitmapped[2]` / "due word uint16_t bitmapped".** Neither the legacy app nor the new app's `DataTypeWidth` switch handles this label. Did v2.15 silently drop those reads too, or is the bitmapped variable consumed via a different code path?
+3. **API-only DataTypes.** Are there other API-emitted strings beyond `UInt8/16/32` and `Bitmapped[2]` that need handling? The sample so far is one board.
+
+## Next bench actions
+
+- [ ] Enumerate every distinct `dataType` string the API returns across all boards.
+- [ ] Capture one telemetry session with `DictionaryApi__ApiKey=""` env override (forces Excel fallback) — confirm telemetry decodes correctly under Excel-only.
+- [ ] Capture the same session with API enabled — confirm zero decoded values.
+- [ ] If both confirm: pick a normalization approach with the dictionaries-manager owner.
+
+## Not the cause of
+
+- The Boot Interface tab being missing — that's a UI removal, see [#95](https://github.com/luca-veronelli-stem/stem-device-manager/issues/95).
+- The senderId endianness question — independent hypothesis, see [#97](https://github.com/luca-veronelli-stem/stem-device-manager/issues/97).
+
+## Changelog of this investigation
+
+| Date | Note |
+|---|---|
+| 2026-05-21 | Filed [#96](https://github.com/luca-veronelli-stem/stem-device-manager/issues/96); initial findings from code reading + API/Excel diff. |


### PR DESCRIPTION
## Summary

- Adds `Docs/Investigations/` with two seed notebooks for the open investigations surfaced 2026-05-21.
- `telemetry-datatype-vocabulary.md` — current state of [#96](https://github.com/luca-veronelli-stem/stem-device-manager/issues/96) (API/Excel DataType string mismatch silently drops telemetry).
- `senderid-endianness.md` — current state of [#97](https://github.com/luca-veronelli-stem/stem-device-manager/issues/97) (PacketDecoder may read TP senderId in the wrong byte order).
- Mirrors the existing `Docs/BenchLog-Spec001.md` / `Docs/PerfRegression-Spec001.md` pattern — committed markdown that accumulates findings via diffs rather than GitHub issue comments.

## Test plan

- [x] Render both files on GitHub, confirm tables and code blocks look right.
- [x] Cross-check the file paths against the tracking issue bodies (`#96` and `#97` both reference these paths).

Refs #96, #97.