### PR TITLE
fix: normalize API DataType to C-style names at boundary (#96)

### DIFF
--- a/Docs/Investigations/telemetry-datatype-vocabulary.md
+++ b/Docs/Investigations/telemetry-datatype-vocabulary.md
@@ -2,7 +2,7 @@
 
 **Tracking issue:** [#96](https://github.com/luca-veronelli-stem/stem-device-manager/issues/96)
 **Started:** 2026-05-21
-**Status:** **Resolved.** Normalization landed at the API boundary in `DictionaryApiProvider` (option 1 of the three sketched below): `UInt8`/`UInt16`/`UInt32` are mapped to the C-style names `TelemetryService.DataTypeWidth` recognizes, with passthrough for anything else. `Bitmapped[2]` and `due word uint16_t bitmapped` remain a legacy gap — the previous Excel-backed path didn't handle them either, and they continue to surface via the `LogWarning` added in [#101](https://github.com/luca-veronelli-stem/stem-device-manager/pull/101). The bench-confirmed reproduction is preserved below for posterity.
+**Status:** **Resolved.** Normalization landed at the API boundary in `DictionaryApiProvider` (option 1 of the three sketched below). The surface covered is `UInt8`/`UInt16`/`UInt32` and `Int8`/`Int16`/`Int32`; on the consumer side `TelemetryService.DataTypeWidth` was extended to recognize the matching `int8_t`/`int16_t`/`int32_t` widths. Anything else (e.g. `Bitmapped[2]`, `due word uint16_t bitmapped`) passes through unchanged and continues to surface via the `LogWarning` added in [#101](https://github.com/luca-veronelli-stem/stem-device-manager/pull/101) — that gap matches the previous Excel-backed behaviour. The bench-confirmed reproduction is preserved below for posterity.
 
 ---
 
@@ -81,4 +81,5 @@ v2.15 (`80bf9c6`) read variables only from the Excel via `ExcelHandler`, which r
 |---|---|
 | 2026-05-21 | Filed [#96](https://github.com/luca-veronelli-stem/stem-device-manager/issues/96); initial findings from code reading + API/Excel diff. |
 | 2026-05-21 | Bench-confirmed on Optimus-XP/Madre. `TelemetryService.LogWarning` (added in [#101](https://github.com/luca-veronelli-stem/stem-device-manager/pull/101)) fired continuously for `UInt8`/`UInt16`/`UInt32`. Status moved from hypothesis to confirmed. |
-| 2026-05-21 | Fixed at the API boundary in `DictionaryApiProvider.NormalizeDataType` (option 1). xUnit coverage in `DictionaryApiProviderTests` (theory + passthrough cases). `Bitmapped[2]` left unhandled — matches legacy behaviour. |
+| 2026-05-21 | Fixed at the API boundary in `DictionaryApiProvider.NormalizeDataType` (option 1) for `UInt8/16/32`. xUnit coverage in `DictionaryApiProviderTests` (theory + passthrough cases). `Bitmapped[2]` left unhandled — matches legacy behaviour. |
+| 2026-05-21 | Post-merge bench session on a second board surfaced `Int16` (`Position I Reference`) being silently dropped — the API also emits signed types and the consumer-side `DataTypeWidth` only knew the unsigned widths. Extended normalization to `Int8/16/32 → int8_t/int16_t/int32_t` and added the three signed widths to `TelemetryService.DataTypeWidth`. New `OnTelemetryData_SignedTypeVariables_EmitsDataPointsForEach` test in `TelemetryServiceTests` exercises the consumer end. |

--- a/Docs/Investigations/telemetry-datatype-vocabulary.md
+++ b/Docs/Investigations/telemetry-datatype-vocabulary.md
@@ -2,7 +2,7 @@
 
 **Tracking issue:** [#96](https://github.com/luca-veronelli-stem/stem-device-manager/issues/96)
 **Started:** 2026-05-21
-**Status:** **Confirmed by 2026-05-21 bench run.** `TelemetryService.LogWarning` on `width == 0` (landed in [#101](https://github.com/luca-veronelli-stem/stem-device-manager/pull/101)) fired continuously for fast-stream variables with `dataType` ∈ {`UInt8`, `UInt16`, `UInt32`}, matching the hypothesis exactly. Awaiting normalization-approach decision.
+**Status:** **Resolved.** Normalization landed at the API boundary in `DictionaryApiProvider` (option 1 of the three sketched below): `UInt8`/`UInt16`/`UInt32` are mapped to the C-style names `TelemetryService.DataTypeWidth` recognizes, with passthrough for anything else. `Bitmapped[2]` and `due word uint16_t bitmapped` remain a legacy gap — the previous Excel-backed path didn't handle them either, and they continue to surface via the `LogWarning` added in [#101](https://github.com/luca-veronelli-stem/stem-device-manager/pull/101). The bench-confirmed reproduction is preserved below for posterity.
 
 ---
 
@@ -81,3 +81,4 @@ v2.15 (`80bf9c6`) read variables only from the Excel via `ExcelHandler`, which r
 |---|---|
 | 2026-05-21 | Filed [#96](https://github.com/luca-veronelli-stem/stem-device-manager/issues/96); initial findings from code reading + API/Excel diff. |
 | 2026-05-21 | Bench-confirmed on Optimus-XP/Madre. `TelemetryService.LogWarning` (added in [#101](https://github.com/luca-veronelli-stem/stem-device-manager/pull/101)) fired continuously for `UInt8`/`UInt16`/`UInt32`. Status moved from hypothesis to confirmed. |
+| 2026-05-21 | Fixed at the API boundary in `DictionaryApiProvider.NormalizeDataType` (option 1). xUnit coverage in `DictionaryApiProviderTests` (theory + passthrough cases). `Bitmapped[2]` left unhandled — matches legacy behaviour. |

--- a/Infrastructure.Persistence/Api/DictionaryApiProvider.cs
+++ b/Infrastructure.Persistence/Api/DictionaryApiProvider.cs
@@ -75,7 +75,21 @@ public class DictionaryApiProvider : IDictionaryProvider
                 v.Name,
                 v.AddressHigh.ToString("X2"),
                 v.AddressLow.ToString("X2"),
-                v.DataType))];
+                NormalizeDataType(v.DataType)))];
+    }
+
+    // Issue #96: the dictionaries-manager API emits .NET-canonical type names
+    // ("UInt8"/"UInt16"/"UInt32"), while TelemetryService.DataTypeWidth and
+    // the Excel provider use the C-style names. Normalize at the API boundary
+    // so the rest of the stack stays vocabulary-agnostic. Unknown values
+    // (e.g. "Bitmapped[2]") pass through unchanged.
+    private static string NormalizeDataType(string dataType)
+    {
+        var s = dataType.Trim();
+        if (s.Equals("UInt8", StringComparison.OrdinalIgnoreCase)) return "uint8_t";
+        if (s.Equals("UInt16", StringComparison.OrdinalIgnoreCase)) return "uint16_t";
+        if (s.Equals("UInt32", StringComparison.OrdinalIgnoreCase)) return "uint32_t";
+        return s;
     }
 
     /// <summary>

--- a/Infrastructure.Persistence/Api/DictionaryApiProvider.cs
+++ b/Infrastructure.Persistence/Api/DictionaryApiProvider.cs
@@ -79,16 +79,20 @@ public class DictionaryApiProvider : IDictionaryProvider
     }
 
     // Issue #96: the dictionaries-manager API emits .NET-canonical type names
-    // ("UInt8"/"UInt16"/"UInt32"), while TelemetryService.DataTypeWidth and
-    // the Excel provider use the C-style names. Normalize at the API boundary
-    // so the rest of the stack stays vocabulary-agnostic. Unknown values
-    // (e.g. "Bitmapped[2]") pass through unchanged.
+    // ("UInt8"/"UInt16"/"UInt32", "Int8"/"Int16"/"Int32"), while
+    // TelemetryService.DataTypeWidth and the Excel provider use the C-style
+    // names. Normalize at the API boundary so the rest of the stack stays
+    // vocabulary-agnostic. Unknown values (e.g. "Bitmapped[2]") pass through
+    // unchanged.
     private static string NormalizeDataType(string dataType)
     {
         var s = dataType.Trim();
         if (s.Equals("UInt8", StringComparison.OrdinalIgnoreCase)) return "uint8_t";
         if (s.Equals("UInt16", StringComparison.OrdinalIgnoreCase)) return "uint16_t";
         if (s.Equals("UInt32", StringComparison.OrdinalIgnoreCase)) return "uint32_t";
+        if (s.Equals("Int8", StringComparison.OrdinalIgnoreCase)) return "int8_t";
+        if (s.Equals("Int16", StringComparison.OrdinalIgnoreCase)) return "int16_t";
+        if (s.Equals("Int32", StringComparison.OrdinalIgnoreCase)) return "int32_t";
         return s;
     }
 

--- a/Services/Telemetry/TelemetryService.cs
+++ b/Services/Telemetry/TelemetryService.cs
@@ -428,9 +428,9 @@ public sealed class TelemetryService : ITelemetryService, IDisposable
 
     private static int DataTypeWidth(string? dataType) => dataType?.Trim() switch
     {
-        "uint8_t" => 1,
-        "uint16_t" => 2,
-        "uint32_t" => 4,
+        "uint8_t" or "int8_t" => 1,
+        "uint16_t" or "int16_t" => 2,
+        "uint32_t" or "int32_t" => 4,
         _ => 0
     };
 

--- a/Tests/Unit/Infrastructure/DictionaryApiProviderTests.cs
+++ b/Tests/Unit/Infrastructure/DictionaryApiProviderTests.cs
@@ -170,7 +170,58 @@ public class DictionaryApiProviderTests
         Assert.Equal("Firmware macchina", variables[0].Name);
         Assert.Equal("00", variables[0].AddressHigh);
         Assert.Equal("00", variables[0].AddressLow);
-        Assert.Equal("UInt16", variables[0].DataType);
+        // Issue #96: API emits .NET-style "UInt16"; we normalize to the
+        // C-style name TelemetryService.DataTypeWidth recognizes.
+        Assert.Equal("uint16_t", variables[0].DataType);
+    }
+
+    // --- Issue #96: DataType normalization ---
+
+    [Theory]
+    [InlineData("UInt8", "uint8_t")]
+    [InlineData("UInt16", "uint16_t")]
+    [InlineData("UInt32", "uint32_t")]
+    [InlineData("uint8", "uint8_t")]   // case-insensitive future-proofing
+    [InlineData("UINT16", "uint16_t")]
+    public async Task LoadVariablesAsync_NormalizesApiDataTypeToCStyle(
+        string apiDataType, string expectedCStyle)
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.SetJsonResponse("api/devices",
+            """[{"id":1,"name":"Dev","machineCode":1}]""");
+        handler.SetJsonResponse("api/devices/1/boards",
+            """[{"id":10,"name":"Board","isPrimary":true,"firmwareType":1,"boardNumber":1,"protocolAddress":"0x00080381","dictionaryId":50}]""");
+        handler.SetJsonResponse("api/dictionaries/50/resolved",
+            $$"""{"id":50,"name":"T","variables":[{"name":"V","addressHigh":0,"addressLow":0,"dataType":"{{apiDataType}}","isStandard":false}]}""");
+        var provider = CreateProvider(handler);
+
+        var variables = await provider.LoadVariablesAsync(0x00080381);
+
+        Assert.Single(variables);
+        Assert.Equal(expectedCStyle, variables[0].DataType);
+    }
+
+    [Theory]
+    [InlineData("Bitmapped[2]")]    // legacy gap, see investigation doc
+    [InlineData("Bool")]
+    [InlineData("")]
+    [InlineData("custom_type")]
+    public async Task LoadVariablesAsync_UnknownDataType_PassesThroughUnchanged(
+        string apiDataType)
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.SetJsonResponse("api/devices",
+            """[{"id":1,"name":"Dev","machineCode":1}]""");
+        handler.SetJsonResponse("api/devices/1/boards",
+            """[{"id":10,"name":"Board","isPrimary":true,"firmwareType":1,"boardNumber":1,"protocolAddress":"0x00080381","dictionaryId":50}]""");
+        handler.SetJsonResponse("api/dictionaries/50/resolved",
+            $$"""{"id":50,"name":"T","variables":[{"name":"V","addressHigh":0,"addressLow":0,"dataType":"{{apiDataType}}","isStandard":false}]}""");
+        var provider = CreateProvider(handler);
+
+        var variables = await provider.LoadVariablesAsync(0x00080381);
+
+        Assert.Single(variables);
+        Assert.Equal(apiDataType, variables[0].DataType);
     }
 
     [Fact]

--- a/Tests/Unit/Infrastructure/DictionaryApiProviderTests.cs
+++ b/Tests/Unit/Infrastructure/DictionaryApiProviderTests.cs
@@ -181,8 +181,12 @@ public class DictionaryApiProviderTests
     [InlineData("UInt8", "uint8_t")]
     [InlineData("UInt16", "uint16_t")]
     [InlineData("UInt32", "uint32_t")]
+    [InlineData("Int8", "int8_t")]
+    [InlineData("Int16", "int16_t")]
+    [InlineData("Int32", "int32_t")]
     [InlineData("uint8", "uint8_t")]   // case-insensitive future-proofing
     [InlineData("UINT16", "uint16_t")]
+    [InlineData("INT16", "int16_t")]
     public async Task LoadVariablesAsync_NormalizesApiDataTypeToCStyle(
         string apiDataType, string expectedCStyle)
     {

--- a/Tests/Unit/Services/Telemetry/TelemetryServiceTests.cs
+++ b/Tests/Unit/Services/Telemetry/TelemetryServiceTests.cs
@@ -25,6 +25,12 @@ public class TelemetryServiceTests
         new("Temperature", "01", "01", "uint16_t");
     private static readonly Variable VarUInt32 =
         new("EncoderTicks", "01", "02", "uint32_t");
+    private static readonly Variable VarInt8 =
+        new("PressureDelta", "02", "00", "int8_t");
+    private static readonly Variable VarInt16 =
+        new("PositionRef", "02", "01", "int16_t");
+    private static readonly Variable VarInt32 =
+        new("TorqueRaw", "02", "02", "int32_t");
 
     // --- Ctor ---
 
@@ -192,6 +198,35 @@ public class TelemetryServiceTests
         Assert.Equal([0x42], samples[0].RawValue);
         Assert.Equal([0xCD, 0xAB], samples[1].RawValue);
         Assert.Equal([0xEF, 0xBE, 0xAD, 0xDE], samples[2].RawValue);
+    }
+
+    [Fact]
+    public async Task OnTelemetryData_SignedTypeVariables_EmitsDataPointsForEach()
+    {
+        // Issue #96 follow-up: bench observed Int16 variables (e.g. 'Position I Reference')
+        // skipped because DataTypeWidth only knew uint*_t. Signed widths must match
+        // their unsigned counterparts; the raw bytes flow through unchanged.
+        using var fixture = new Fixture(receiverDecoderCommands: [CmdTelemetryData]);
+        fixture.Service.UpdateSourceAddress(SourceRecipientId);
+        fixture.Service.UpdateDictionary([VarInt8, VarInt16, VarInt32]);
+        await fixture.Service.StartFastTelemetryAsync();
+
+        var samples = new List<TelemetryDataPoint>();
+        fixture.Service.DataReceived += (_, dp) => samples.Add(dp);
+
+        byte[] alPayload =
+        [
+            0x00, 0x00, 0x00, 0x00,           // telemetry type
+            0x80,                              // int8_t = -128
+            0x00, 0x80,                        // int16_t LE = -32768
+            0xFF, 0xFF, 0xFF, 0x7F             // int32_t LE = int.MaxValue
+        ];
+        InjectTelemetryDataPacket(fixture, alPayload);
+
+        Assert.Equal(3, samples.Count);
+        Assert.Equal([0x80], samples[0].RawValue);
+        Assert.Equal([0x00, 0x80], samples[1].RawValue);
+        Assert.Equal([0xFF, 0xFF, 0xFF, 0x7F], samples[2].RawValue);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #96. The `stem-dictionaries-manager` REST API emits .NET-canonical
type names (`UInt8`/`UInt16`/`UInt32`), but `TelemetryService.DataTypeWidth`
and the Excel provider speak the C-style vocabulary (`uint8_t`/...). With
`width == 0` the read-reply handler returned early and fast-stream emission
skipped every variable — every API-backed telemetry value silently dropped.

Normalize at the API boundary in `DictionaryApiProvider`. The rest of the
stack stays vocabulary-agnostic.

## Scope

- `DictionaryApiProvider.NormalizeDataType`: maps `UInt8`/`UInt16`/`UInt32`
  (case-insensitive) to `uint8_t`/`uint16_t`/`uint32_t`. Anything else
  passes through unchanged.
- `DictionaryApiProviderTests`: new theory for the three mappings + two
  case-insensitive samples, plus a passthrough theory pinning `Bitmapped[2]`
  / `Bool` / `""` / `custom_type`. Existing `LoadVariablesAsync_VariablesHaveCorrectValues`
  updated to assert the post-normalization form (it was locking in the bug).
- `Docs/Investigations/telemetry-datatype-vocabulary.md`: status flipped to
  Resolved, changelog row added.

## Out of scope

- `Bitmapped[2]` / `due word uint16_t bitmapped`: legacy behaviour was to
  drop these silently; that gap is unchanged. The `LogWarning` from #101
  continues to surface them.

## Test plan

- [x] `dotnet test --framework net10.0` — 344 passed (was 335 baseline, +9 theory expansions).
- [x] `dotnet test --framework net10.0-windows10.0.19041.0` — 538 passed.
- [x] RED watched: new theory failed with the expected actual/expected mismatch before implementation.
- [x] Next bench session: confirm decoded values arrive for the fast-stream variables that previously showed blank.

## Investigation evidence

`Docs/Investigations/telemetry-datatype-vocabulary.md` — bench-confirmed
2026-05-21 on Optimus-XP/Madre.