### PR TITLE
fix: tolerate unknown reply commands in PacketDecoder

### DIFF
--- a/Services/DependencyInjection.cs
+++ b/Services/DependencyInjection.cs
@@ -2,6 +2,7 @@ using Core.Interfaces;
 using Core.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Services.Cache;
 using Services.Configuration;
 using Services.Protocol;
@@ -56,7 +57,9 @@ public static class DependencyInjection
         // PacketDecoder vuoto: UpdateDictionary verrà chiamato dalla DictionaryCache
         // dopo IDictionaryProvider.LoadProtocolDataAsync(). Pattern consolidato dalla
         // Fase 1 — il dizionario arriva async da Azure, non sincronizzabile in DI.
-        services.AddSingleton<IPacketDecoder>(_ => new PacketDecoder([], [], []));
+        services.AddSingleton<IPacketDecoder>(sp => new PacketDecoder(
+            [], [], [],
+            sp.GetService<ILogger<PacketDecoder>>()));
 
         // Cache del dizionario + gestore del canale attivo (Fase 3).
         services.AddSingleton<DictionaryCache>();

--- a/Services/Protocol/PacketDecoder.cs
+++ b/Services/Protocol/PacketDecoder.cs
@@ -1,6 +1,8 @@
 using System.Collections.Immutable;
 using Core.Interfaces;
 using Core.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Services.Protocol;
 
@@ -35,13 +37,16 @@ public sealed class PacketDecoder : IPacketDecoder
     private const int VariableLowIndex = 10;
 
     private DictionarySnapshot _snapshot;
+    private readonly ILogger<PacketDecoder> _logger;
 
     public PacketDecoder(
         IReadOnlyList<Command> commands,
         IReadOnlyList<Variable> variables,
-        IReadOnlyList<ProtocolAddress> addresses)
+        IReadOnlyList<ProtocolAddress> addresses,
+        ILogger<PacketDecoder>? logger = null)
     {
         _snapshot = Build(commands, variables, addresses);
+        _logger = logger ?? NullLogger<PacketDecoder>.Instance;
     }
 
     /// <summary>
@@ -62,10 +67,11 @@ public sealed class PacketDecoder : IPacketDecoder
     {
         if (packet.IsEmpty || packet.Length < MinPayloadLength) return null;
         var snapshot = Volatile.Read(ref _snapshot);
-        var command = ResolveCommand(packet.Payload, snapshot);
+        var senderId = ReadSenderIdBigEndian(packet.Payload);
+        var command = ResolveCommand(packet.Payload, snapshot)
+            ?? SynthesizeUnknownReplyCommand(packet.Payload, senderId);
         if (command is null) return null;
         var variable = ResolveVariable(command, packet.Payload, snapshot);
-        var senderId = ReadSenderIdBigEndian(packet.Payload);
         var sender = snapshot.FindSender(senderId);
         var appPayload = ExtractApplicationPayload(packet.Payload);
         return new AppLayerDecodedEvent(
@@ -75,6 +81,27 @@ public sealed class PacketDecoder : IPacketDecoder
             sender?.DeviceName ?? "",
             sender?.BoardName ?? "",
             senderId);
+    }
+
+    /// <summary>
+    /// Defense in depth for incomplete dictionaries: when a reply-shaped command
+    /// (high bit set on cmdHigh) is unknown, synthesize a placeholder so the
+    /// AppLayerDecoded event still fires and bench observers see the frame
+    /// instead of a silent drop. Fire-side unknowns (high bit clear) stay
+    /// rejected to avoid masking corrupt frames. See #100.
+    /// </summary>
+    private Command? SynthesizeUnknownReplyCommand(ImmutableArray<byte> payload, uint senderId)
+    {
+        byte h = payload[CommandHighIndex];
+        byte l = payload[CommandLowIndex];
+        if ((h & 0x80) == 0) return null;
+        _logger.LogWarning(
+            "Unknown reply command 0x{High:X2}{Low:X2} from sender 0x{SenderId:X8}; synthesizing placeholder.",
+            h, l, senderId);
+        return new Command(
+            $"Unknown reply 0x{h:X2}{l:X2}",
+            h.ToString("X2"),
+            l.ToString("X2"));
     }
 
     private static DictionarySnapshot Build(

--- a/Tests/Unit/Services/Protocol/PacketDecoderTests.cs
+++ b/Tests/Unit/Services/Protocol/PacketDecoderTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using Core.Models;
+using Microsoft.Extensions.Logging;
 using Services.Protocol;
 
 namespace Tests.Unit.Services.Protocol;
@@ -34,12 +35,45 @@ public class PacketDecoderTests
     }
 
     [Fact]
-    public void Decode_ComandoSconosciuto_ReturnsNull()
+    public void Decode_UnknownFireSideCommand_ReturnsNullWithoutLogging()
     {
-        var decoder = new PacketDecoder([ReadVariable], [], []);
-        var packet = MakePacket(cmdHigh: 0xAA, cmdLow: 0xBB);
+        // Fire-side codes (high bit clear) are still rejected. Accepting them
+        // would mask legitimately corrupt frames — only reply-shaped unknowns
+        // (high bit set) get a synthesized placeholder. See #100.
+        var logger = new RecordingLogger<PacketDecoder>();
+        var decoder = new PacketDecoder([ReadVariable], [], [], logger);
+        var packet = MakePacket(cmdHigh: 0x00, cmdLow: 0x2B);
 
         Assert.Null(decoder.Decode(packet));
+        Assert.Empty(logger.Entries);
+    }
+
+    [Fact]
+    public void Decode_UnknownReplyCommand_SynthesizesPlaceholderAndLogsWarning()
+    {
+        // Bench instance 2026-05-21: BLE reply 0x802B from Optimus-XP/Madre
+        // (sender 0x000A0441) was silently dropped because 0x802B is not registered
+        // in the Azure dictionary. The consumer-side fix synthesizes a placeholder
+        // command so the event still fires, and logs a warning for bench visibility.
+        var logger = new RecordingLogger<PacketDecoder>();
+        var decoder = new PacketDecoder([], [], [], logger);
+        var packet = MakePacket(
+            senderId: 0x000A0441u,
+            cmdHigh: 0x80,
+            cmdLow: 0x2B);
+
+        var evt = decoder.Decode(packet);
+
+        Assert.NotNull(evt);
+        Assert.Equal("Unknown reply 0x802B", evt.Command.Name);
+        Assert.Equal("80", evt.Command.CodeHigh);
+        Assert.Equal("2B", evt.Command.CodeLow);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Equal((byte)0x80, entry.State["High"]);
+        Assert.Equal((byte)0x2B, entry.State["Low"]);
+        Assert.Equal(0x000A0441u, entry.State["SenderId"]);
     }
 
     [Fact]
@@ -382,5 +416,38 @@ public class PacketDecoderTests
         builder.Add(0xCC); // crc byte 1
         builder.Add(0xCD); // crc byte 2
         return builder.ToImmutable();
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var props = new Dictionary<string, object?>();
+            if (state is IReadOnlyList<KeyValuePair<string, object?>> kv)
+            {
+                foreach (var pair in kv)
+                {
+                    props[pair.Key] = pair.Value;
+                }
+            }
+            Entries.Add(new LogEntry(logLevel, formatter(state, exception), props, exception));
+        }
+
+        public sealed record LogEntry(
+            LogLevel Level,
+            string Message,
+            IReadOnlyDictionary<string, object?> State,
+            Exception? Exception);
     }
 }


### PR DESCRIPTION
Closes #100.

## What changed

When `ResolveCommand` returns null for a reply-shaped code (high bit set on `cmdHigh`), `PacketDecoder.Decode` now synthesizes a placeholder `Command` named `"Unknown reply 0xHHLL"` and logs a warning, instead of returning null. The `AppLayerDecoded` event fires and the awaiting caller of `SendCommandAndWaitReplyAsync` gets the reply.

Fire-side unknowns (high bit clear) stay rejected to avoid masking corrupt frames — accepting them would let a one-bit flip in `cmdHigh` pass through as a synthesized event.

## Why

Bench-confirmed silent drop 2026-05-21 over BLE to Optimus-XP/Madre (`0x000A0441`):

```
TX:  cmd=002B payloadLen=0 (Unlock Cambio Firmware Schede H7)
RX:  len=12 TP[0..11]=00-00-0A-04-41-00-03-80-2B-00-F5-A5
     decode-null reason=unknown-cmd(0x802B)
```

`0x802B` is a valid reply, but it isn't registered in the Azure dictionary, so the consumer threw the frame away. The upstream dictionary fix is tracked in [`stem-dictionaries-manager#79`](https://github.com/luca-veronelli-stem/stem-dictionaries-manager/issues/79); this PR is the consumer-side defense in depth.

## Logging

`ILogger<PacketDecoder>` is an optional 4th ctor parameter (defaults to `NullLogger`), mirroring `ProtocolService`'s shape. The DI registration in `Services/DependencyInjection.cs` resolves it from the host container, so production runs with logging. The warning carries `{High:X2}`, `{Low:X2}`, and `{SenderId:X8}` as named structured-logging parameters.

## Tests

`Tests/Unit/Services/Protocol/PacketDecoderTests.cs`:

- **`Decode_UnknownReplyCommand_SynthesizesPlaceholderAndLogsWarning`** — new positive case. Reproduces the bench frame (sender `0x000A0441`, cmd `0x802B`), asserts the synthesized `Command` and the single `LogWarning` entry with the expected named parameters.
- **`Decode_UnknownFireSideCommand_ReturnsNullWithoutLogging`** — replaces the old `Decode_ComandoSconosciuto_ReturnsNull` test (which used `0xAABB`, now reply-shaped under the new behavior). Asserts the negative case at `0x002B` and that no log entry is emitted.
- **`RecordingLogger<T>`** — minimal manual `ILogger<T>` fake nested in the test class, capturing level + structured state per the project's no-mocking-library rule.

## Results

- 350/350 net10.0 tests pass (was 349; +1 net new test).
- `dotnet build -c Release` clean (0 warnings, 0 errors).

## Not addressed here

- Upstream dictionary gap (`stem-dictionaries-manager#79`) — fixed there, not here.
- Variable resolution on a synthesized command — `IsReadOrWriteVariable` still gates on the codes, so a synthesized `0x80 0x01` placeholder would attempt `FindVariable` and get `null` (no matching variable in the snapshot). Out of scope; the bench case `0x802B` doesn't hit that branch.