### PR TITLE
fix(telemetry): send stop unconditionally after reconnect (#104)

### DIFF
--- a/Services/Cache/ConnectionManager.cs
+++ b/Services/Cache/ConnectionManager.cs
@@ -49,6 +49,7 @@ public sealed class ConnectionManager : IDisposable
     private IBootService? _activeBoot;
     private ITelemetryService? _activeTelemetry;
     private ChannelKind _activeChannel;
+    private uint _lastSourceRecipient;
     private bool _disposed;
 
     public ConnectionManager(
@@ -189,6 +190,7 @@ public sealed class ConnectionManager : IDisposable
         ICommunicationPort? oldPort;
         ChannelKind previousChannel;
         bool wasConnected;
+        uint carriedSourceRecipient;
         lock (_stateLock)
         {
             // issue #51: clicking the already-active channel menu item must be
@@ -204,6 +206,15 @@ public sealed class ConnectionManager : IDisposable
             oldProtocol = _activeProtocol;
             oldBoot = _activeBoot;
             oldTelemetry = _activeTelemetry;
+            // issue #104: the telemetry source recipient is the logical address
+            // of the board the user is talking to; it must survive a port-drop
+            // rebuild, otherwise StopTelemetryAsync (and the rest of the
+            // telemetry API) sends to recipient 0 and the device ignores it.
+            // DisposeActiveServices snapshots _lastSourceRecipient on every
+            // tear-down (explicit switch + implicit port-drop), so by this
+            // point it carries the most recent value even if a drop already
+            // nulled _activeTelemetry.
+            carriedSourceRecipient = _lastSourceRecipient;
             previousChannel = _activeChannel;
             wasConnected = _state == ConnectionState.Connected;
             oldPort = wasConnected ? _ports.GetValueOrDefault(previousChannel) : null;
@@ -238,6 +249,8 @@ public sealed class ConnectionManager : IDisposable
             var newTelemetry = new TelemetryService(
                 newProtocol,
                 logger: _loggerFactory.CreateLogger<TelemetryService>());
+            if (carriedSourceRecipient != 0u)
+                newTelemetry.UpdateSourceAddress(carriedSourceRecipient);
             newTelemetry.DataReceived += OnActiveTelemetryData;
 
             bool channelChanged;
@@ -383,7 +396,13 @@ public sealed class ConnectionManager : IDisposable
     private void DisposeActiveServices(
         IProtocolService? protocol, IBootService? boot, ITelemetryService? telemetry)
     {
-        if (telemetry is not null) telemetry.DataReceived -= OnActiveTelemetryData;
+        if (telemetry is not null)
+        {
+            // issue #104: remember the source recipient before disposal so the
+            // next SwitchToAsync rebuild can restore it on the new instance.
+            lock (_stateLock) _lastSourceRecipient = telemetry.SourceRecipientId;
+            telemetry.DataReceived -= OnActiveTelemetryData;
+        }
         if (boot is not null) boot.ProgressChanged -= OnActiveBootProgress;
         if (telemetry is IDisposable td)
         {

--- a/Services/Telemetry/TelemetryService.cs
+++ b/Services/Telemetry/TelemetryService.cs
@@ -191,7 +191,9 @@ public sealed class TelemetryService : ITelemetryService, IDisposable
         uint sourceAddr;
         lock (_stateLock)
         {
-            if (!_isRunning) return;
+            // No _isRunning short-circuit on purpose (issue #104): a fresh
+            // instance built after BLE reconnect has _isRunning = false but
+            // the device may still be streaming. Send the stop unconditionally.
             _isRunning = false;
             sourceAddr = _sourceRecipientId;
         }

--- a/Tests/Unit/Services/Cache/ConnectionManagerTests.cs
+++ b/Tests/Unit/Services/Cache/ConnectionManagerTests.cs
@@ -367,6 +367,28 @@ public class ConnectionManagerTests
     }
 
     [Fact]
+    public async Task SwitchToAsync_AfterPortDropAndReconnect_PreservesSourceRecipient()
+    {
+        // Issue #104: the BLE-tab reconnect path (BLE_WF_Tab → SwitchToAsync)
+        // does not re-call UpdateSourceAddress on the new TelemetryService, so
+        // a Stop button click after a drop+reconnect was sending the stop to
+        // recipient 0 (device ignored it). The manager itself must carry the
+        // source recipient across the rebuild.
+        const uint sourceRecipient = 0xCAFEBABEu;
+        using var fixture = new Fixture();
+        fixture.BleDriver.IsConnected = true;
+        await fixture.Manager.SwitchToAsync(ChannelKind.Ble);
+        fixture.Manager.CurrentTelemetry!.UpdateSourceAddress(sourceRecipient);
+
+        fixture.BleDriver.RaiseConnectionStatusChanged(false);
+        fixture.BleDriver.IsConnected = true;
+        fixture.BleDriver.RaiseConnectionStatusChanged(true);
+        await fixture.Manager.SwitchToAsync(ChannelKind.Ble);
+
+        Assert.Equal(sourceRecipient, fixture.Manager.CurrentTelemetry!.SourceRecipientId);
+    }
+
+    [Fact]
     public async Task PortDisconnected_StillForwardsStateChangedEvent()
     {
         using var fixture = new Fixture();

--- a/Tests/Unit/Services/Telemetry/TelemetryServiceTests.cs
+++ b/Tests/Unit/Services/Telemetry/TelemetryServiceTests.cs
@@ -128,14 +128,19 @@ public class TelemetryServiceTests
     }
 
     [Fact]
-    public async Task StopTelemetryAsync_WhenStopped_NoOp()
+    public async Task StopTelemetryAsync_WhenNotRunning_StillSendsStop()
     {
+        // Issue #104: after a BLE reconnect ConnectionManager builds a fresh
+        // TelemetryService with _isRunning = false, but the device may still
+        // be streaming. Stop must reach the device regardless of local state.
         using var fixture = new Fixture();
+        fixture.Service.UpdateSourceAddress(SourceRecipientId);
 
         await fixture.Service.StopTelemetryAsync();
 
         Assert.False(fixture.Service.IsRunning);
-        Assert.Empty(fixture.Port.SentPayloads);
+        Assert.Single(fixture.Port.SentPayloads);
+        AssertCommandIs(fixture.Port.SentPayloads[0], cmdHi: 0x00, cmdLo: 0x17);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #104.

## What

Two vertical commits, both needed to actually close the bench-observed bug:

1. **`fix(telemetry): send stop unconditionally after reconnect`** — drops the `if (!_isRunning) return` guard in `TelemetryService.StopTelemetryAsync`. After a BLE reconnect the fresh instance has `_isRunning = false` but the device may still be streaming, so the guard short-circuited the stop send.
2. **`fix(connection): preserve telemetry source recipient across reconnect`** — `ConnectionManager.SwitchToAsync` rebuilds the `TelemetryService` trio on every switch with `_sourceRecipientId = 0`. The BLE-tab reconnect path (`BLE_WF_Tab` → `SwitchToAsync`) doesn't re-call `UpdateSourceAddress`, so after commit 1 the stop was firing but going to recipient 0 and being ignored by the device. Snapshot the value in `DisposeActiveServices` and restore on rebuild.

## Why two commits

Commit 1 in isolation: bench evidence showed the stop firing (BLE loopback `Arresta telemetria` with app SenderId) but no firmware ack. The device wasn't addressed.
Commit 2 fixes the addressing. Together they close the user-facing symptom.

## Test

- RED → GREEN flip for `StopTelemetryAsync_WhenNotRunning_StillSendsStop` (was `StopTelemetryAsync_WhenStopped_NoOp` — that test enshrined the bug).
- New `SwitchToAsync_AfterPortDropAndReconnect_PreservesSourceRecipient`.
- Full suite green on both TFMs: 350 net10.0, 545 net10.0-windows.
- Pending: bench re-run before merge.

## Out of scope

The latent `Form1.SelectedCommand = comboBoxCommand.SelectedIndex` fragility tracked in #107.