### PR TITLE
fix: derive command bytes from selected Command, not combobox index (#107)

### DIFF
--- a/GUI.Windows/CommandSelection.cs
+++ b/GUI.Windows/CommandSelection.cs
@@ -1,0 +1,18 @@
+using System.Globalization;
+using Core.Models;
+
+namespace StemPC;
+
+internal static class CommandSelection
+{
+    public static (byte High, byte Low)? ResolveBytes(IReadOnlyList<Command> commands, int selectedIndex)
+    {
+        if (selectedIndex < 0 || selectedIndex >= commands.Count)
+            return null;
+
+        var cmd = commands[selectedIndex];
+        var high = byte.Parse(cmd.CodeHigh, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        var low = byte.Parse(cmd.CodeLow, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        return (high, low);
+    }
+}

--- a/GUI.Windows/Forms/Form1.cs
+++ b/GUI.Windows/Forms/Form1.cs
@@ -74,6 +74,11 @@ namespace StemPC
         List<Command> Comandi = new();
         List<Variable> Dizionario = new();
 
+        // Commands currently visible in comboBoxCommand, in display order
+        // (after the reply filter). comboBoxCommand.SelectedIndex indexes this
+        // list to recover the underlying Command at send time.
+        private readonly List<Command> _displayedCommands = new();
+
         //**********************************
         //  STEM Protocol variables/classes
         //**********************************
@@ -407,13 +412,16 @@ namespace StemPC
 
             _terminal.WriteLog("--------------------------------------------------------------------");
             comboBoxCommand.Items.Clear();
+            _displayedCommands.Clear();
             foreach (Command item in Comandi)
             {
                 UpdateTerminal($"Comando: {item.Name}, codeH: {item.CodeHigh}, codeL: {item.CodeLow}");
-                if (!comboBoxCommand.Items.Contains(item.Name)
-                    && !item.Name.Contains("risposta")
-                    && !item.Name.Contains("Risposta"))
-                    comboBoxCommand.Items.Add(item.Name);
+                if (item.Name.Contains("risposta") || item.Name.Contains("Risposta"))
+                    continue;
+                if (comboBoxCommand.Items.Contains(item.Name))
+                    continue;
+                comboBoxCommand.Items.Add(item.Name);
+                _displayedCommands.Add(item);
             }
 
             // Pre-selezione device/board iniziale (blocco #7 in PREPROCESSOR_DIRECTIVES.md):
@@ -482,9 +490,15 @@ namespace StemPC
                 return;
             }
 
-            byte cmdHi = (byte)(this.SelectedCommand >> 8);
-            byte cmdLo = (byte)this.SelectedCommand;
-            var command = new Command("UserSend", cmdHi.ToString("X2"), cmdLo.ToString("X2"));
+            // Resolve the command bytes from the actual selected Command, not
+            // from the dropdown index (see issue #107: index != CodeHigh/Low).
+            var bytes = CommandSelection.ResolveBytes(_displayedCommands, comboBoxCommand.SelectedIndex);
+            if (bytes is null)
+            {
+                MessageBox.Show("Select a command first!");
+                return;
+            }
+            var command = new Command("UserSend", bytes.Value.High.ToString("X2"), bytes.Value.Low.ToString("X2"));
 
             var byteList = new List<byte>();
 

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -44,6 +44,7 @@
     <Compile Remove="Unit\CircularProgressBar\**" />
     <Compile Remove="Unit\Infrastructure\Protocol\**" />
     <Compile Remove="Unit\Tabs\**" />
+    <Compile Remove="Unit\Forms\**" />
     <Compile Remove="Unit\Core\Models\ButtonIndicatorTests.cs" />
     <!-- ConnectionManager test usa real CanPort/BlePort/SerialPort (Infrastructure.Protocol), Windows-only -->
     <Compile Remove="Unit\Services\Cache\ConnectionManagerTests.cs" />

--- a/Tests/Unit/Forms/CommandSelectionTests.cs
+++ b/Tests/Unit/Forms/CommandSelectionTests.cs
@@ -1,0 +1,76 @@
+using Core.Models;
+using StemPC;
+
+namespace Tests.Unit.Forms;
+
+public class CommandSelectionTests
+{
+    private static readonly IReadOnlyList<Command> SampleCommands = new[]
+    {
+        new Command("Read variable",  "00", "01"),
+        new Command("Write variable", "00", "02"),
+        new Command("Stop telemetry", "00", "17"),
+        new Command("Reply read",     "80", "01"),
+    };
+
+    [Fact]
+    public void ResolveBytes_ValidIndex_ReturnsCodeOfSelectedCommand()
+    {
+        var bytes = CommandSelection.ResolveBytes(SampleCommands, 2);
+
+        Assert.NotNull(bytes);
+        Assert.Equal(0x00, bytes!.Value.High);
+        Assert.Equal(0x17, bytes.Value.Low);
+    }
+
+    [Fact]
+    public void ResolveBytes_FirstEntry_ReturnsCodeNotIndexZero()
+    {
+        var bytes = CommandSelection.ResolveBytes(SampleCommands, 0);
+
+        Assert.NotNull(bytes);
+        Assert.Equal(0x00, bytes!.Value.High);
+        Assert.Equal(0x01, bytes.Value.Low);
+    }
+
+    [Fact]
+    public void ResolveBytes_HighByteNonZero_ParsesHexNotDecimal()
+    {
+        var bytes = CommandSelection.ResolveBytes(SampleCommands, 3);
+
+        Assert.NotNull(bytes);
+        Assert.Equal(0x80, bytes!.Value.High);
+        Assert.Equal(0x01, bytes.Value.Low);
+    }
+
+    [Fact]
+    public void ResolveBytes_IndexDoesNotEqualCode_RegressionForIssue107()
+    {
+        // The bug: cmdHi/cmdLo were derived from SelectedIndex, not the command's
+        // actual code. Index 2 here would have sent (0x00, 0x02); the real code
+        // is (0x00, 0x17). The helper must return the latter.
+        var bytes = CommandSelection.ResolveBytes(SampleCommands, 2);
+
+        Assert.NotNull(bytes);
+        Assert.NotEqual<byte>(2, bytes!.Value.Low);
+        Assert.Equal(0x17, bytes.Value.Low);
+    }
+
+    [Fact]
+    public void ResolveBytes_NegativeIndex_ReturnsNull()
+    {
+        Assert.Null(CommandSelection.ResolveBytes(SampleCommands, -1));
+    }
+
+    [Fact]
+    public void ResolveBytes_IndexOutOfRange_ReturnsNull()
+    {
+        Assert.Null(CommandSelection.ResolveBytes(SampleCommands, SampleCommands.Count));
+    }
+
+    [Fact]
+    public void ResolveBytes_EmptyList_ReturnsNull()
+    {
+        Assert.Null(CommandSelection.ResolveBytes(Array.Empty<Command>(), 0));
+    }
+}


### PR DESCRIPTION
## Summary

`Form1.SendPS_Async` derived `cmdHi`/`cmdLo` from `(short)comboBoxCommand.SelectedIndex` — the position of the selected entry in the filtered dropdown — and sent that as the actual STEM application-layer command code. The current dictionary made several commands work by sheer coincidence (e.g. `Arresta telemetria` happens to land at index `0x17`, its real code). Any dictionary reorder, new non-reply entry, or reply whose name lacks `risposta`/`Risposta` shifts every following send to the wrong opcode.

## What changed

- New `_displayedCommands` field on `Form1`: a `List<Command>` maintained in lock-step with `comboBoxCommand` (same reply filter, same order).
- New `CommandSelection.ResolveBytes(IReadOnlyList<Command>, int)` helper in `GUI.Windows/`: given the displayed list + the current selection, returns the real `(CodeHigh, CodeLow)` byte pair (parsing hex), or `null` when the index is out of range.
- `SendPS_Async` calls the helper instead of bit-shifting `SelectedCommand`. An empty selection now shows ``Select a command first!`` and returns rather than blasting `00 00`.

## Tests

`Tests/Unit/Forms/CommandSelectionTests.cs` (7 xUnit cases on the `net10.0-windows` leg) — covers the indexed-code lookup, the explicit regression for issue #107 (index 2 returning `0x17`, not `0x02`), high-byte hex parsing (`0x80`), and null on negative / out-of-range / empty inputs.

Full suite: 350 passed (`net10.0`) + 552 passed (`net10.0-windows`).

## Constitution check

- I. Pragmatic — single small helper, no new interface or DI surface; smallest change that breaks the index-as-code coupling.
- II. Correctness — `byte.Parse` with `NumberStyles.HexNumber` + `CultureInfo.InvariantCulture`; early-return on null helper result.
- III. Dual-TFM testing — helper is Windows-side; tests live on the `net10.0-windows` leg per `docs/Standards/TESTING.md` (the helper depends on a `Core.Models.Command` list but lives near WinForms because it encodes a UI selection concern). `net10.0` leg stays green.

## Out of scope (per issue #107)

- The `comboBoxVariables` index-as-position bug at `Form1.cs:491-501`.
- The `SelectedCommand == 1 || == 2` UI trigger at `Form1.cs:549` (toggles the variables column). It still reads the dropdown index, which is correct for "user is looking at slot N" semantics but semantically obscure — left for a follow-up that consolidates the read/write-variable scope.

Closes #107.