### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,11 @@ StyleCopReport.xml
 # Never merged; kept in the working tree for long-running branches.
 WIP/
 
+# Local-only appsettings override holding the Azure dictionary API key (#94).
+# The committed appsettings.json ships with an empty ApiKey; this file (or the
+# DictionaryApi__ApiKey env var) supplies the real value at runtime.
+GUI.Windows/appsettings.Production.json
+
 # Chutzpah Test files
 _Chutzpah*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.4.0] - 2026-05-21
+
+Maintenance release on top of v0.3.0: one minor feature (file logger sink + decoder /
+telemetry silent-drop warnings), four bench-driven fixes, and a security rotation
+relocating the Azure dictionary API key out of the committed `appsettings.json`. No
+breaking changes.
+
 ### Added
 
 - **Restored Boot Interface tab** for non-SPARK firmware uploads (#95). PR #80 removed
@@ -27,6 +36,83 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   used path — true for SPARK, but every other variant (TopLift, Eden, Optimus,
   R3L, Eden-BS8, Sherpa Slim, Gradino, Sally-Cab, O3Z-Tech) has no other firmware-upload
   UI. The tab now ships unconditionally; SPARK users can simply ignore it.
+
+- **Per-process file logger sink** + structured `LogWarning` on every silent-drop in
+  `PacketDecoder` and `TelemetryService`. Surfaced during the #96 investigation: the
+  previous Debug-only sink discarded discard-frame events as soon as a non-debugger
+  session exited, leaving bench post-mortems with no audit trail. The new sink writes
+  to `<AppContext.BaseDirectory>/logs/app-<yyyyMMdd-HHmmss>.log` and is disposed
+  explicitly on exit (DI does not transfer ownership for instance-registered
+  providers). Both `PacketDecoder` and `TelemetryService` now emit a `LogWarning` when
+  a frame is dropped silently, with the frame fields needed to correlate against the
+  API DataType vocabulary captured in
+  [`Docs/Investigations/telemetry-datatype-vocabulary.md`](Docs/Investigations/telemetry-datatype-vocabulary.md).
+
+### Fixed
+
+- **#96 — API DataType normalization at the boundary.** `DictionaryApiProvider` was
+  receiving free-form type strings (`"int8"`, `"INT16"`, `"sint32"`) from the Azure
+  dictionary API while `PacketDecoder` / `TelemetryService` expected C-style names
+  (`Int8`, `Int16`, `Int32`, `UInt8`, …). Result: telemetry and read-reply frames for
+  variables typed with anything outside the strict C-style list were silently dropped
+  — no exception, no log. Fix: normalize all incoming DataType strings at the API
+  boundary to the C-style canonical form, and extend `DataTypeWidth` to cover signed
+  Int8/16/32 (the previous table only handled unsigned widths). Bench-confirmed
+  against the SPARK-UC reference machine; full evidence in
+  [`Docs/Investigations/telemetry-datatype-vocabulary.md`](Docs/Investigations/telemetry-datatype-vocabulary.md).
+
+- **#100 — `PacketDecoder` tolerance of unknown high-bit-set reply commands.** The
+  decoder previously rejected any command whose high-order bit was set if it wasn't
+  in its known-replies table, treating them as malformed. Firmware in the wild emits
+  a growing set of reply commands (vendor extensions, debug responses) that aren't
+  yet in our vocabulary. Fix: log a warning and skip unknown high-bit-set commands
+  instead of throwing.
+
+- **#104 — Telemetry can be stopped after BLE reconnect.** `TelemetryService` cached
+  the recipient address from the first connection and didn't refresh it on reconnect;
+  subsequent stop attempts sent `CMD_STOP_TELEMETRY` to the stale recipient, the
+  device ignored it, and the GUI was left believing telemetry was still streaming.
+  Two-part fix: `ConnectionManager` now preserves the telemetry source recipient
+  across the reconnect (commit `a900b9c`), and `TelemetryService` sends stop
+  unconditionally on reconnect instead of guarding on a desynced internal state flag
+  (commit `66aead4`). Bench-confirmed on the SPARK-UC after the BLE notification
+  thread was suspected of partially desyncing service state during the disconnect
+  window.
+
+- **#107 — `Form1.SelectedCommand` uses command bytes, not combobox index.** A
+  refactor regression: `SendPS_Async` was assembling the command payload from the
+  combobox `SelectedIndex` rather than the underlying `Bytes` property of the
+  selected `Command` record. With dictionaries where the displayed order did not
+  match the on-wire ordinal, the wrong command was sent every time. Fix: derive
+  bytes from the selected `Command` directly.
+
+### Investigated (no code change)
+
+- **#97 — `senderId` byte order on the wire.** Bench observation suggested the RX
+  `senderId` may be reversed relative to the firmware-side encoding. After
+  investigation: no code change warranted; the apparent inversion is a property of
+  the firmware-side packing, not a decoder bug. Notes in
+  [`Docs/Investigations/senderid-endianness.md`](Docs/Investigations/senderid-endianness.md)
+  for the next time this comes up.
+
+### Security
+
+- **#94 — Azure dictionary API key relocated to environment variable (stopgap).**
+  The `ApiKeys:StemDeviceManager` slot on the Azure App Service was **rotated** as
+  part of this release. The old key was burned (it sat in git history, in the
+  `bitbucket/main` mirror, and in `GUI.Windows/appsettings.json` on every developer's
+  disk) and is now inert. The committed `appsettings.json` ships with an empty
+  `ApiKey` placeholder; the real key is provided at runtime via the
+  `DictionaryApi__ApiKey` environment variable, or via a gitignored
+  `GUI.Windows/appsettings.Production.json` override. Cross-consumer isolation:
+  rotating the `StemDeviceManager` slot does not affect any other consumer
+  (`ButtonPanelTester`, `ButtonPanelTesterSeedRefresh`, `GlobalService`,
+  `ProductionTracker` each have their own slot in `stem-dictionaries-manager`'s
+  `ApiKeyMiddleware`). No git history rewrite — the rotation is what makes the
+  historical key safe; force-push across two remotes is more risk than benefit.
+  Closes #94 partially (stopgap portion only); the deferred DPAPI / zero-touch /
+  per-installation revocation work remains open for when `stem-device-manager`
+  starts shipping externally.
 
 ---
 
@@ -395,6 +481,7 @@ State of the legacy project before the modernization wave. ~330 commits, ~56k LO
 
 ## Version URLs
 
-[Unreleased]: https://github.com/luca-veronelli-stem/stem-device-manager/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/luca-veronelli-stem/stem-device-manager/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/luca-veronelli-stem/stem-device-manager/releases/tag/v0.4.0
 [0.3.0]: https://github.com/luca-veronelli-stem/stem-device-manager/releases/tag/v0.3.0
 [0.2.15]: https://bitbucket.org/stem-fw/stem-device-manager/src/80bf9c6/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Infrastructure.Persistence/ [net10.0]                — dictionary data provide
 Infrastructure.Protocol/    [net10.0;net10.0-windows] — HW ports (CanPort/BlePort/SerialPort) + legacy drivers (Legacy/)
 Services/       [net10.0]                            — pure logic (ProtocolService, TelemetryService, BootService, ConnectionManager, DictionaryCache)
 GUI.Windows/            [net10.0-windows, WinForms]          — GUI + DI entry point (no more embedded protocol)
-Tests/          [dual TFM: net10.0 + net10.0-windows] — 292 tests net10.0 / 470 tests net10.0-windows
+Tests/          [dual TFM: net10.0 + net10.0-windows] — 350 tests net10.0 / 552 tests net10.0-windows
 Lean/          [Lean 4]                             — formalizations of extracted types (Phase1/)
 ```
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
 	<!-- Centralized version -->
-	<Version>0.3.0</Version>
-	<FileVersion>0.3.0.0</FileVersion>
-	<AssemblyVersion>0.3.0.0</AssemblyVersion>
+	<Version>0.4.0</Version>
+	<FileVersion>0.4.0.0</FileVersion>
+	<AssemblyVersion>0.4.0.0</AssemblyVersion>
 
 	<!-- Author / company metadata -->
 	<Authors>Michele Pignedoli, Luca Veronelli</Authors>

--- a/GUI.Windows/Forms/Form1.cs
+++ b/GUI.Windows/Forms/Form1.cs
@@ -27,7 +27,7 @@ namespace StemPC
         private readonly BLEManager _bleManager;
         private readonly ILogger<Form1> _logger;
 
-        public const string Software_Version = "0.3.0";
+        public const string Software_Version = "0.4.0";
 
         // Canale hardware corrente selezionato. Le mutazioni vengono propagate a
         // ConnectionManager via SwitchToAsync.

--- a/GUI.Windows/Program.cs
+++ b/GUI.Windows/Program.cs
@@ -9,7 +9,7 @@ using Services;
 ///*****************************************************************************
 /// @file    Program.cs
 /// @author  Michele Pignedoli, Luca Veronelli
-///@version  0.3.0
+///@version  0.4.0
 /// @date    20/10/2025
 /// @brief   STEM Device Manager Main program body
 ///*****************************************************************************
@@ -24,6 +24,14 @@ using Services;
 ///          ProtocolService/TelemetryService/BootService, ConnectionManager,
 ///          DictionaryCache, removal of #if device variants (runtime selection),
 ///          Spark BLE firmware stabilization (spec-001), Lean 4 invariants.
+/// 0.4.0: + File logger sink + decoder/telemetry silent-drop warnings.
+///        + Restored Boot Interface tab for non-SPARK firmware uploads (#95).
+///        + Fix: API DataType normalization + signed Int8/16/32 widths (#96),
+///          telemetry stop after BLE reconnect (#104), unknown reply commands
+///          tolerated by PacketDecoder (#100), command bytes from selected
+///          Command not combobox index (#107).
+///        + Security: rotated Azure dictionary API key; key relocated to
+///          DictionaryApi__ApiKey env var (#94 stopgap).
 ///
 /// TODO:
 /// - Completare decodifica faults

--- a/GUI.Windows/appsettings.json
+++ b/GUI.Windows/appsettings.json
@@ -1,7 +1,7 @@
 {
   "DictionaryApi": {
     "BaseUrl": "https://app-dictionaries-manager-prod.azurewebsites.net/",
-    "ApiKey": "XwDk-!PuXk@GWydY_fdy*wieX@_e8di@cjRMHLV2ispT.3YEYU",
+    "ApiKey": "",
     "TimeoutSeconds": 30
   },
   "Device": {

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ﻿# Stem.Device.Manager
 
-[![Version](https://img.shields.io/badge/version-0.3.0-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.4.0-blue)](./CHANGELOG.md)
 [![.NET](https://img.shields.io/badge/.NET-10.0-512BD4)](https://dotnet.microsoft.com/)
-[![Tests](https://img.shields.io/badge/tests-292%20%2F%20470-brightgreen)](./Tests/)
+[![Tests](https://img.shields.io/badge/tests-350%20%2F%20552-brightgreen)](./Tests/)
 [![License](https://img.shields.io/badge/license-Proprietary-red)](#license)
 
 > **Desktop application for managing, diagnosing and communicating with STEM devices over the proprietary multi-channel protocol (CAN, BLE, Serial).**
-> **Last updated:** 2026-04-29
+> **Last updated:** 2026-05-21
 
 ---
 
@@ -25,7 +25,7 @@ Stem Device Manager is a Windows desktop tool used to:
 The codebase is being modernized incrementally. Phases 1–4 of the refactor are complete:
 
 - `Form1.cs` has been reduced to a thin shell (~731 LOC) on top of `ConnectionManager` + `DictionaryCache`.
-- **292 cross-platform tests** + **470 Windows-only tests** (xUnit).
+- **350 cross-platform tests** + **552 Windows-only tests** (xUnit).
 - Multi-project layout:
   - **Core** (`net10.0`) — domain models + interfaces.
   - **Infrastructure.Persistence** (`net10.0`) — dictionary providers (Azure API + Excel + Fallback).
@@ -53,7 +53,7 @@ The codebase is being modernized incrementally. Phases 1–4 of the refactor are
 | **Bootloader** | ✅ | Firmware update (classic + Spark batch) |
 | **Telemetry** | ✅ | Variable reads + OxyPlot charts (slow + fast) |
 | **Code generator** | ✅ | Generates `sp_config.h` |
-| **Automated tests** | ✅ | 292 cross-platform + 470 Windows (xUnit) |
+| **Automated tests** | ✅ | 350 cross-platform + 552 Windows (xUnit) |
 
 ---
 
@@ -109,7 +109,7 @@ dotnet publish GUI.Windows/GUI.Windows.csproj `
     -p:PublishSingleFile=true `
     -p:IncludeNativeLibrariesForSelfExtract=true `
     -p:EnableCompressionInSingleFile=true `
-    -o publish/v0.3.0
+    -o publish/v0.4.0
 ```
 
 The Excel dictionary (`Resources/Dizionari STEM.xlsx`) is already an embedded resource, so the fallback works without shipping a separate file. `appsettings.json` is the only loose file copied next to the `.exe`; if you want it embedded too, set `Device:Variant` and `DictionaryApi:*` via environment variables (see [Configuration](#configuration)) and remove the `appsettings.json` from the publish folder.
@@ -142,15 +142,9 @@ $env:DictionaryApi__BaseUrl  = "https://..."
 $env:Device__Variant         = "TopLift"
 ```
 
-### Security note (v0.3.0 field test)
+### API key (v0.4.0 stopgap)
 
-- The Azure dictionary API requires an API key. v0.3.0 ships with the test key in `appsettings.json` to keep the field-test loop fast.
-- Risk is low: the API only serves dictionaries (commands / addresses / variables) — no device control, no PII.
-- Mitigations applied for the field test:
-  1. Single-file publish bundles `appsettings.json` next to the `.exe` — no separate config file to leak in transit.
-  2. The Excel fallback works offline: a temporary key revocation does not brick the tool.
-  3. The key can be overridden at runtime via the `DictionaryApi__ApiKey` env var, so each technician's machine can be moved to a per-user key without rebuilding.
-- Before v1.0: rotate the key, remove it from `appsettings.json`, require it from `DPAPI`-encrypted user secrets or Windows Credential Manager (`CredRead`/`CredWrite`).
+The Azure dictionary API key is **not committed**. `appsettings.json` ships with an empty `ApiKey` placeholder; set `DictionaryApi__ApiKey` in the environment before first run, or place the value in a gitignored `GUI.Windows/appsettings.Production.json`. See [issue #94](https://github.com/luca-veronelli-stem/stem-device-manager/issues/94) for the full security rationale (current stopgap + deferred DPAPI / zero-touch provisioning posture for external supplier deployment).
 
 ---
 


### PR DESCRIPTION
## Summary

Maintenance release on top of v0.3.0. One minor feature (file-logger sink + decoder/telemetry silent-drop warnings), four bench-driven fixes, and a security rotation moving the Azure dictionary API key out of the committed `appsettings.json`. No breaking changes.

- Closes #95, #96, #100, #104, #107.
- Investigated only: #97 (no code change; notes in `Docs/Investigations/senderid-endianness.md`).
- Partial fix for #94 — v0.4.0 stopgap only; the deferred DPAPI / zero-touch / per-installation revocation work remains open in #94 for when the app starts shipping externally.

## Commits

- **`b759030` chore(release): bump to 0.4.0** — version pins (`Directory.Build.props`, `Form1.cs::Software_Version`, `Program.cs` `@version` header + history line).
- **`815191c` security: relocate Dictionary API key to env var (#94)** — `appsettings.json` `ApiKey` emptied, `.gitignore` guards `GUI.Windows/appsettings.Production.json`. The `ApiKeys:StemDeviceManager` slot on the Azure App Service was rotated before this commit landed; the historical value is now inert.
- **`2cac9cb` docs: changelog 0.4.0 + refresh test counts** — new `[0.4.0] - 2026-05-21` section in CHANGELOG folding all the above; README badges/prose bumped (version 0.4.0, tests 350 / 552, last updated 2026-05-21, publish path); CLAUDE.md test counts refreshed; v0.3.0 field-test security paragraph in README replaced with a short API-key blurb pointing at #94.

## Test plan

- [x] `dotnet build -c Release Stem.Device.Manager.slnx`: green (0 warnings, 0 errors)
- [x] `dotnet test Tests/Tests.csproj -c Release`: **350 / 552** pass on both TFMs
- [x] Bisect-safety walk (`git rebase main release/v0.4.0 -x "build && test"`): each of the 3 commits independently green
- [x] Smoke run with `$env:DictionaryApi__ApiKey` set against `dotnet run GUI.Windows`: all Azure REST calls authenticated (200), dictionary loaded, BLE channel initialized cleanly
- [x] CI green on `release/v0.4.0` (Build Gate Linux + Windows both pass)