### PR TITLE
fix: load appsettings.Production.json overlay + sync SHIPPED_README (v0.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,41 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.4.1] - 2026-05-22
+
+Patch release closing the docs/code drift introduced by the v0.4.0 security
+stopgap (#94, PR #109). The runtime override for the Azure dictionary API key
+via `GUI.Windows/appsettings.Production.json` was documented in three places
+(CHANGELOG, README, `.gitignore` comment) but `Program.cs` never registered
+the overlay, so the file was silently ignored — leaving technicians who
+followed the documented procedure on the embedded Excel fallback with no
+error message. The shipped end-user README still claimed an embedded test
+key was bundled, which was no longer true after the rotation.
+
+### Fixed
+
+- **#110 — `appsettings.Production.json` overlay now actually loads.**
+  `GUI.Windows/Program.cs` registers the overlay between the committed
+  `appsettings.json` and `AddEnvironmentVariables()`; the documented Route 2
+  for `DictionaryApi:ApiKey` finally works as advertised. `reloadOnChange:
+  false` because credentials are not expected to mutate live. No behavior
+  change for the env-var route (Route 3) or the empty-key fallback (Route 1).
+
+### Changed
+
+- **`Docs/SHIPPED_README.txt` rewritten for v0.4.1** (Italian, end-user-facing
+  for STEM technicians installing the published exe). The previous v0.3.0
+  text stated *"la chiave di test e' embedded"* and listed `DictionaryApi__ApiKey`
+  as optional — both flatly false after the v0.4.0 rotation. New text:
+  - Marks the API key as **mandatory** (sezione VARIABILE OBBLIGATORIA) and
+    documents the silent-401 → Excel-fallback chain that happens if it's
+    missing.
+  - Documents both override routes: env var (OPZIONE A) and gitignored
+    `appsettings.Production.json` next to the exe (OPZIONE B, with a JSON
+    template and an explicit "custodirlo come un segreto" warning).
+  - Adds the unset/empty-key bullet to the `USO OFFLINE` section so the
+    silent-fallback symptom now has a documented mitigation.
+
 ## [0.4.0] - 2026-05-21
 
 Maintenance release on top of v0.3.0: one minor feature (file logger sink + decoder /
@@ -481,7 +516,8 @@ State of the legacy project before the modernization wave. ~330 commits, ~56k LO
 
 ## Version URLs
 
-[Unreleased]: https://github.com/luca-veronelli-stem/stem-device-manager/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/luca-veronelli-stem/stem-device-manager/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/luca-veronelli-stem/stem-device-manager/releases/tag/v0.4.1
 [0.4.0]: https://github.com/luca-veronelli-stem/stem-device-manager/releases/tag/v0.4.0
 [0.3.0]: https://github.com/luca-veronelli-stem/stem-device-manager/releases/tag/v0.3.0
 [0.2.15]: https://bitbucket.org/stem-fw/stem-device-manager/src/80bf9c6/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
 	<!-- Centralized version -->
-	<Version>0.4.0</Version>
-	<FileVersion>0.4.0.0</FileVersion>
-	<AssemblyVersion>0.4.0.0</AssemblyVersion>
+	<Version>0.4.1</Version>
+	<FileVersion>0.4.1.0</FileVersion>
+	<AssemblyVersion>0.4.1.0</AssemblyVersion>
 
 	<!-- Author / company metadata -->
 	<Authors>Michele Pignedoli, Luca Veronelli</Authors>

--- a/Docs/SHIPPED_README.txt
+++ b/Docs/SHIPPED_README.txt
@@ -1,5 +1,5 @@
 ================================================================================
-					   STEM DEVICE MANAGER v0.3.0
+					   STEM DEVICE MANAGER v0.4.1
 							  STEM E.m.s.
 ================================================================================
 
@@ -71,35 +71,55 @@ non valido, viene usata la variante "Generic".
 ================================================================================
 
 L'applicazione scarica i dizionari di comandi/variabili dall'API Azure
-"Stem.Dictionaries.Manager". I valori di default sono gia' inclusi e
-funzionano senza configurazione aggiuntiva (la chiave di test e' embedded).
+"Stem.Dictionaries.Manager". A partire dalla v0.4.0 la chiave API NON e'
+piu' inclusa nell'eseguibile: deve essere configurata prima del primo
+avvio (vedi PROCEDURA piu' sotto), altrimenti l'applicazione si avvia
+comunque ma funziona offline contro il dizionario Excel embedded (che
+potrebbe non essere aggiornato - vedi sezione USO OFFLINE).
 
-Per sovrascrivere la configurazione (chiave personale, endpoint diverso,
-timeout piu' alto) impostare le seguenti variabili d'ambiente:
+VARIABILE OBBLIGATORIA:
+-----------------------
+1. DictionaryApi__ApiKey
+   Chiave API per l'autenticazione. Senza questa chiave l'applicazione
+   parte ma non riesce a contattare l'API Azure (errore 401 dal server)
+   e ricade silenziosamente sul dizionario Excel embedded.
 
 VARIABILI OPZIONALI:
 --------------------
-1. DictionaryApi__ApiKey
-   Chiave API per l'autenticazione. Se non configurata viene usata quella
-   di default embedded nel file appsettings.json.
-
-2. DictionaryApi__BaseUrl
+1. DictionaryApi__BaseUrl
    URL base dell'API (default:
    https://app-dictionaries-manager-prod.azurewebsites.net/).
 
-3. DictionaryApi__TimeoutSeconds
+2. DictionaryApi__TimeoutSeconds
    Timeout in secondi per le chiamate HTTP (default: 30).
 
-4. Device__SenderId
+3. Device__SenderId
    Indirizzo STEM del mittente (default: 8). Cambiarlo solo se richiesto
    esplicitamente dal supporto.
 
 PROCEDURA:
-1. Richiedere la chiave API personale al contatto di supporto (se necessario).
-2. Aprire Windows PowerShell ed eseguire:
+1. Richiedere la chiave API personale al contatto di supporto.
+
+2. Scegliere UNA delle due opzioni di configurazione:
+
+   OPZIONE A - Variabile d'ambiente.
+   Aprire Windows PowerShell ed eseguire:
 		[Environment]::SetEnvironmentVariable("DictionaryApi__ApiKey", "<API_KEY>", "User")
    Oppure da Prompt dei comandi:
 		setx DictionaryApi__ApiKey "<API_KEY>"
+
+   OPZIONE B - File appsettings.Production.json accanto all'eseguibile.
+   Creare nella stessa cartella di GUI.Windows.exe un file di nome
+   "appsettings.Production.json" con il seguente contenuto:
+		{
+		  "DictionaryApi": {
+		    "ApiKey": "<API_KEY>"
+		  }
+		}
+   Il file viene letto a ogni avvio dell'applicazione; non viene scritto
+   ne' modificato. Custodirlo come un segreto: NON committarlo in alcun
+   repository, NON condividerlo via email/chat.
+
 3. Chiudere e riaprire l'applicazione.
 
 Nota: sostituire <API_KEY> con la chiave fornita.
@@ -109,9 +129,17 @@ Nota: sostituire <API_KEY> con la chiave fornita.
 						 USO OFFLINE
 ================================================================================
 
-Se l'API Azure non e' raggiungibile (rete assente, chiave revocata, server
-down), l'applicazione passa automaticamente al dizionario Excel embedded:
+L'applicazione passa automaticamente al dizionario Excel embedded nei
+seguenti casi:
 
+- API Azure non raggiungibile (rete assente, server down).
+- Chiave API revocata o scaduta (errore 401 dal server).
+- Chiave API non configurata o vuota. ATTENZIONE: questo accade in modo
+  silenzioso al primo avvio se non e' stata seguita la procedura di
+  CONFIGURAZIONE API DIZIONARI - non viene mostrato alcun messaggio
+  d'errore in GUI; l'unica traccia e' nel file di log sotto logs/.
+
+In modalita' offline:
 - I dizionari di comandi/variabili vengono letti dal file Excel incorporato
   nell'eseguibile (nessun file esterno richiesto).
 - Tutte le funzionalita' di comunicazione (CAN/BLE/Serial), bootloader e

--- a/GUI.Windows/Forms/Form1.cs
+++ b/GUI.Windows/Forms/Form1.cs
@@ -27,7 +27,7 @@ namespace StemPC
         private readonly BLEManager _bleManager;
         private readonly ILogger<Form1> _logger;
 
-        public const string Software_Version = "0.4.0";
+        public const string Software_Version = "0.4.1";
 
         // Canale hardware corrente selezionato. Le mutazioni vengono propagate a
         // ConnectionManager via SwitchToAsync.

--- a/GUI.Windows/Program.cs
+++ b/GUI.Windows/Program.cs
@@ -9,7 +9,7 @@ using Services;
 ///*****************************************************************************
 /// @file    Program.cs
 /// @author  Michele Pignedoli, Luca Veronelli
-///@version  0.4.0
+///@version  0.4.1
 /// @date    20/10/2025
 /// @brief   STEM Device Manager Main program body
 ///*****************************************************************************
@@ -32,6 +32,10 @@ using Services;
 ///          Command not combobox index (#107).
 ///        + Security: rotated Azure dictionary API key; key relocated to
 ///          DictionaryApi__ApiKey env var (#94 stopgap).
+/// 0.4.1: + Fix: appsettings.Production.json overlay now actually loads at
+///          runtime, matching the v0.4.0 docs (#110, refs #94).
+///        + SHIPPED_README.txt rewritten for v0.4.1 — API key is required,
+///          no longer claims an embedded test key is present.
 ///
 /// TODO:
 /// - Completare decodifica faults

--- a/GUI.Windows/Program.cs
+++ b/GUI.Windows/Program.cs
@@ -61,6 +61,7 @@ namespace GUI.Windows
             var configuration = new ConfigurationBuilder()
                 .SetBasePath(AppContext.BaseDirectory)
                 .AddJsonFile("appsettings.json", optional: true)
+                .AddJsonFile("appsettings.Production.json", optional: true, reloadOnChange: false)
                 .AddEnvironmentVariables()
                 .Build();
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ﻿# Stem.Device.Manager
 
-[![Version](https://img.shields.io/badge/version-0.4.0-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.4.1-blue)](./CHANGELOG.md)
 [![.NET](https://img.shields.io/badge/.NET-10.0-512BD4)](https://dotnet.microsoft.com/)
 [![Tests](https://img.shields.io/badge/tests-350%20%2F%20552-brightgreen)](./Tests/)
 [![License](https://img.shields.io/badge/license-Proprietary-red)](#license)
 
 > **Desktop application for managing, diagnosing and communicating with STEM devices over the proprietary multi-channel protocol (CAN, BLE, Serial).**
-> **Last updated:** 2026-05-21
+> **Last updated:** 2026-05-22
 
 ---
 
@@ -111,7 +111,7 @@ dotnet publish GUI.Windows/GUI.Windows.csproj `
     -p:PublishSingleFile=true `
     -p:IncludeNativeLibrariesForSelfExtract=true `
     -p:EnableCompressionInSingleFile=true `
-    -o publish/v0.4.0
+    -o publish/v0.4.1
 ```
 
 The Excel dictionary (`Resources/Dizionari STEM.xlsx`) is already an embedded resource, so the fallback works without shipping a separate file. `appsettings.json` is the only loose file copied next to the `.exe`; if you want it embedded too, set `Device:Variant` and `DictionaryApi:*` via environment variables (see [Configuration](#configuration)) and remove the `appsettings.json` from the publish folder.


### PR DESCRIPTION
## Summary

Patch release closing the docs/code drift introduced by the v0.4.0 security stopgap (#94, PR #109). Three vertical commits:

1. **`fix(config):`** — `GUI.Windows/Program.cs` now registers `appsettings.Production.json` as a runtime overlay between the committed `appsettings.json` and `AddEnvironmentVariables()`. The documented Route 2 for `DictionaryApi:ApiKey` finally works as advertised. `reloadOnChange: false` because credentials don't mutate live.
2. **`chore(release):`** — version pins 0.4.0 → 0.4.1 across `Directory.Build.props`, `Form1.Software_Version`, `Program.cs` `@version` header + history line, README badge / last-updated / publish path.
3. **`docs:`** — `Docs/SHIPPED_README.txt` rewritten for v0.4.1 (Italian, end-user-facing): API key marked **mandatory**, both override routes documented (env var + `appsettings.Production.json`), USO OFFLINE warns about the silent-fallback trap. CHANGELOG `[0.4.1]` section + `[Unreleased]` reset + version-URL footnotes extended.

Each commit builds + passes the full 902-test suite on its own (rebase-walked with `-x "dotnet build && dotnet test"`).

## Test plan

### Build + tests
- [x] `dotnet build Stem.Device.Manager.slnx -c Release` — clean.
- [x] `dotnet test Tests/Tests.csproj -c Release` — 350 / 552 = 902 passing.
- [x] `git rebase github/main -x "dotnet build -c Release && dotnet test --no-build"` — every commit green (bisect-safe).

### Smoke matrix (live, Windows bench, 2026-05-22)

Published `bin/Release/net10.0-windows10.0.19041.0/win-x64/GUI.Windows.exe`. Status-bar chip from a TEMP debug indicator (`FallbackDictionaryProvider.LastUsedSource`).

| # | Setup | Status chip | `logs/app-*.log` evidence |
|---|---|---|---|
| 1 | `appsettings.Production.json` with `ApiKey` next to exe, no env var | green **API** | 18 × `Received HTTP response headers ... - 200` against `app-dictionaries-manager-prod.azurewebsites.net` (`/api/devices`, `/api/devices/N/boards`, `/api/commands`), then `ConnectionManager: State Disconnected -> Connecting -> Connected on Ble`. |
| 2 | `$env:DictionaryApi__ApiKey` only, no `Production.json` | green **API** | Same HTTP sequence as #1, all 200s. Regression guard for the existing env-var route — no behavior change. |
| 3 | Neither set | gold **Excel** (no fallback subtext) | Only the ConnectionManager BLE transitions; **zero** `DictionaryApiProvider` log lines. |

### Finding worth flagging

Scenario 3 is the documented v0.4.0 trap. It does **not** produce a `401 → fallback` chain as initially expected — in [`Infrastructure.Persistence/DependencyInjection.cs`](../blob/fix/0.4.1-production-overlay/Infrastructure.Persistence/DependencyInjection.cs#L38), an empty/whitespace \`ApiKey\` short-circuits the API registration entirely and registers Excel-only. So the misconfigured technician sees:

- No GUI error.
- No HTTP request in the log (because no HttpClient is even registered).
- Silently stale embedded Excel dictionary.

The new `Docs/SHIPPED_README.txt` `USO OFFLINE` section calls this out as one of three cases, but the line *"l'unica traccia e' nel file di log sotto logs/"* is technically wrong for this specific case — there's no log trace at all. Decision (per discussion): leave the README as-is, capture the gap here in the PR record and address it in a follow-up (proper resolved-key-source startup log line — issue #110 explicitly defers that).

## Refs

- Refs #110 — kept open; intentional to track follow-ups (resolved-key-source log line, optional `appsettings.Production.json.example` template).
- Refs #94 — original v0.4.0 stopgap; this PR closes the doc/code drift but the deferred DPAPI / zero-touch / per-installation revocation work remains open per the v0.4.0 narrative.