### PR TITLE
ci: temporary release.yml for v0.4.x exe artifacts (pre-standards-adoption)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+# =============================================================================
+# TEMPORARY — delete on STEM standards adoption.
+#
+# This hand-authored release workflow is a stopgap until stem-device-manager
+# adopts the STEM standards via eng/apply-repo-standard.ps1. At that point the
+# rollout script overwrites this file with the archetype A caller stub that
+# delegates to the reusable workflow at:
+#   luca-veronelli-stem/standards/.github/workflows/release-archetype-a.yml
+#
+# We can't use the reusable workflow today because this repo doesn't yet
+# follow the canonical archetype A layout (no src/, no global.json, app name
+# is "GUI.Windows" not "<App>.GUI", and the README publish recipe relies on
+# IncludeNativeLibrariesForSelfExtract + EnableCompressionInSingleFile which
+# the current reusable workflow doesn't expose as inputs).
+#
+# Tracked in:
+#   - This repo:    https://github.com/luca-veronelli-stem/stem-device-manager/issues/111
+#   - Standards:    https://github.com/luca-veronelli-stem/standards/issues/106
+# =============================================================================
+
+name: Release
+
+on:
+  push:
+    tags: ['v*.*.*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag (e.g. v0.4.1) — must already exist as a Git tag and a published GitHub Release.'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build + attach single-file exe
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Determine version
+        id: v
+        shell: pwsh
+        run: |
+          $tag = if ($env:GITHUB_REF_NAME -match '^v\d') { $env:GITHUB_REF_NAME } else { '${{ inputs.tag }}' }
+          "tag=$tag"                       | Out-File $env:GITHUB_OUTPUT -Append
+          "version=$($tag.TrimStart('v'))" | Out-File $env:GITHUB_OUTPUT -Append
+
+      - name: Restore
+        run: dotnet restore Stem.Device.Manager.slnx
+
+      - name: Publish (win-x64, single-file, native libs packed, compressed)
+        shell: pwsh
+        run: |
+          dotnet publish GUI.Windows/GUI.Windows.csproj `
+            -c Release -r win-x64 --self-contained `
+            -p:PublishSingleFile=true `
+            -p:IncludeNativeLibrariesForSelfExtract=true `
+            -p:EnableCompressionInSingleFile=true `
+            -p:Version=${{ steps.v.outputs.version }} `
+            -o publish/${{ steps.v.outputs.tag }}
+
+      - name: Upload exe to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: |
+          gh release upload ${{ steps.v.outputs.tag }} `
+            publish/${{ steps.v.outputs.tag }}/GUI.Windows.exe `
+            --clobber

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ Two configurations: `Debug` and `Release`. The device variant (TopLift / Eden / 
 
 ### Single-file publish (field-test executable)
 
-For field tests, publish a self-contained single-file executable that bundles the embedded Excel fallback dictionary (no external files required):
+The **recommended** path is the [`Release` GitHub Actions workflow](./.github/workflows/release.yml): pushing a `v*.*.*` tag (after creating the GitHub Release with `gh release create`) automatically builds the self-contained single-file exe and attaches it to the release. The workflow can also be re-run on demand via `gh workflow run release.yml -f tag=v0.4.0` to attach the exe to a release that was cut before the workflow existed. The workflow is marked **temporary** until this repo adopts the STEM standards — see [issue #111](https://github.com/luca-veronelli-stem/stem-device-manager/issues/111).
+
+For local field tests (or when Actions is unavailable), the same recipe runs by hand:
 
 ```powershell
 dotnet publish GUI.Windows/GUI.Windows.csproj `


### PR DESCRIPTION
## Summary

Single vertical commit. Adds a hand-authored `.github/workflows/release.yml` that builds the self-contained single-file `GUI.Windows.exe` on every `v*.*.*` tag push (or `workflow_dispatch` with a tag input) and attaches it to the matching GitHub Release object via `gh release upload --clobber`. The release object itself is still created manually with `gh release create` — the workflow only attaches the binary, preserving the current CHANGELOG-extraction ritual.

Explicitly marked TEMPORARY at the top of the file. The rollout script in [`standards`](https://github.com/luca-veronelli-stem/standards) will overwrite it with the archetype A caller stub once `stem-device-manager` adopts the STEM standards. We can't use the reusable workflow today because the current repo layout (no `src/`, no `global.json`, app named `GUI.Windows` not `<App>.GUI`, publish recipe using `IncludeNativeLibrariesForSelfExtract` + `EnableCompressionInSingleFile`) doesn't match what the reusable workflow at [`standards/.github/workflows/release-archetype-a.yml`](https://github.com/luca-veronelli-stem/standards/blob/main/.github/workflows/release-archetype-a.yml) assumes. Conforming is a separate large refactor.

README's "Single-file publish" section now recommends the workflow as the primary path and keeps the local `dotnet publish` recipe as the manual fallback.

## Test plan

- [x] `dotnet build -c Release` + `dotnet test` — 902 passing (CI-only change, no behavior impact).
- [x] **After merge**: trigger `workflow_dispatch` against `v0.4.0` (already published, no exe attached) — confirm job is green and `GUI.Windows.exe` (~80–100 MB) lands on the v0.4.0 release page.
- [x] **First real tag exercise**: when `v0.4.1` is tagged (post #112 merge), the workflow auto-runs and attaches the exe to the v0.4.1 release.
- [x] Smoke run on the downloaded exe from a clean folder with `$env:DictionaryApi__ApiKey` set: Azure auth succeeds, dictionary loads (already verified locally via #112's smoke matrix; this just confirms the workflow's output matches a hand-built exe).

## Sequencing with #112

Per discussion, this PR merges **before** #112 (v0.4.1) so the v0.4.1 tag becomes the workflow's first real-tag exercise. After merging, #112 rebases onto the new `main` to pick up the workflow trivially (no file conflicts: this PR touches `.github/workflows/release.yml` + the README "Single-file publish" section; #112 touches `Program.cs`, `Directory.Build.props`, `Form1.cs`, `Program.cs`, the README badge/last-updated/publish-path, `SHIPPED_README.txt`, `CHANGELOG.md`).

## Sunset

When `stem-device-manager` adopts the STEM standards via `eng/apply-repo-standard.ps1`, the rollout script overwrites `.github/workflows/release.yml` with the archetype A caller stub. The reusable workflow at [`standards/.github/workflows/release-archetype-a.yml`](https://github.com/luca-veronelli-stem/standards/blob/main/.github/workflows/release-archetype-a.yml) then takes over. The standards companion ticket ([`luca-veronelli-stem/standards#106`](https://github.com/luca-veronelli-stem/standards/issues/106)) should land before adoption so the only regression at handover is the loss of `EnableCompressionInSingleFile` (size-only, ~2× larger zip).

## Refs

- Refs #111 — kept open through merge so the sunset trigger ("delete on standards adoption") remains tracked.
- Companion standards work: [`luca-veronelli-stem/standards#106`](https://github.com/luca-veronelli-stem/standards/issues/106).