### PR TITLE
fix: relocate logs to %LocalAppData%, log key source, zip release artifacts (v0.4.3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,13 +70,21 @@ jobs:
         run: |
           Copy-Item Docs/SHIPPED_README.txt publish/${{ steps.v.outputs.tag }}/README.txt
 
-      - name: Upload release artifacts (exe + appsettings.json + README.txt)
+      - name: Bundle release artifacts into a single zip
+        shell: pwsh
+        run: |
+          $zip = "stem-device-manager-${{ steps.v.outputs.tag }}.zip"
+          Compress-Archive `
+            -Path publish/${{ steps.v.outputs.tag }}/GUI.Windows.exe,publish/${{ steps.v.outputs.tag }}/appsettings.json,publish/${{ steps.v.outputs.tag }}/README.txt `
+            -DestinationPath "publish/${{ steps.v.outputs.tag }}/$zip" `
+            -Force
+          Write-Host "Bundled: publish/${{ steps.v.outputs.tag }}/$zip"
+
+      - name: Upload release zip
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: pwsh
         run: |
           gh release upload ${{ steps.v.outputs.tag }} `
-            publish/${{ steps.v.outputs.tag }}/GUI.Windows.exe `
-            publish/${{ steps.v.outputs.tag }}/appsettings.json `
-            publish/${{ steps.v.outputs.tag }}/README.txt `
+            "publish/${{ steps.v.outputs.tag }}/stem-device-manager-${{ steps.v.outputs.tag }}.zip" `
             --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,80 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.4.3] - 2026-05-22
+
+Diagnostics + release-shape patch bundling three changes that close out
+the rough edges surfaced by the v0.4.1 → v0.4.2 silent-Excel-fallback
+incident. Same-day follow-up to v0.4.2. All three changes target the
+"why did my app silently fall back to Excel?" question from different
+angles: a discoverable log line that names the resolved key source, a
+log path that no longer breaks under read-only installs, and a
+release-artifact shape that makes partial downloads impossible.
+
+### Added
+
+- **#114 — Resolved API key source logged at startup.** New
+  `ApiKeySourceDetector` (in `GUI.Windows/Diagnostics/`) inspects
+  `IConfigurationRoot.Providers` in reverse precedence order and
+  classifies the provider that supplied a non-empty
+  `DictionaryApi:ApiKey`. One `LogInformation` line at startup on the
+  `GUI.Windows.Program` category emits the resolved label (`Empty` /
+  `AppSettings` / `ProductionFile` / `Env` / `Unknown`). The key value
+  itself is never read or logged — only the source label. Seven xunit
+  tests cover the 4 supported cases + the precedence ordering
+  (env overrides production, production overrides appsettings) +
+  defensive guard against non-`ConfigurationRoot` inputs. Test count:
+  552 → 559 windows-only. Closes #114.
+
+- **`StemAppData` path-resolution helper** (in
+  `GUI.Windows/Diagnostics/`) — implements the per-app data root
+  convention from the new STEM `APP_DATA` standard
+  ([luca-veronelli-stem/standards#109](https://github.com/luca-veronelli-stem/standards/issues/109),
+  shipped in `standards v1.9.0`). Exposes `GetAppRoot()`, `GetLogsDir()`,
+  `GetCacheDir()`, `GetCredentialsDir()`, `GetDbDir()` helpers that
+  resolve subfolders under `%LocalAppData%\Stem\DeviceManager\` and
+  create them on demand.
+
+### Fixed
+
+- **Logs no longer live next to the exe.** `Program.cs` now writes log
+  files to `%LocalAppData%\Stem\DeviceManager\logs\app-<timestamp>.log`
+  via `StemAppData.GetLogsDir()`, replacing the previous
+  `AppContext.BaseDirectory/logs/` path. The old location broke under
+  read-only install locations (Program Files), lost per-user separation
+  on shared bench machines, and was a contributing factor to the v0.4.2
+  silent-fallback (no writable logs/ folder means no diagnostic when
+  things went sideways). v0.4.3 is the first APP_DATA reference adopter
+  — no migration helper ships because the previous data was per-process
+  session logs with no longterm value (greenfield-adopter pattern per
+  the standard). Technicians who want the legacy `logs/` folder gone
+  can delete it by hand; no in-app cleanup.
+
+### Changed
+
+- **Release artifacts now ship as a single zip.** The Actions release
+  workflow previously uploaded three loose files
+  (`GUI.Windows.exe`, `appsettings.json`, `README.txt`); now it
+  bundles them into `stem-device-manager-<tag>.zip` via
+  `Compress-Archive` before a single `gh release upload --clobber`.
+  The zip shape exists specifically to prevent the v0.4.1-style failure
+  where a technician downloaded only the exe and silently lost the
+  sibling config + procedure. There's no shape of partial download that
+  yields a misconfigured installation from this point forward. The
+  manual `dotnet publish` recipe in `README.md` was updated with a
+  matching `Compress-Archive` step for parity between Actions and local
+  builds.
+
+- **`Docs/SHIPPED_README.txt` rewritten for v0.4.3.** Header bump to
+  v0.4.3. The AVVIO section gains an `IMPORTANTE` line noting that the
+  three extracted files must stay in the same folder. A new section
+  `FILE DI LOG` documents the new log location, how to open the folder
+  via `%LocalAppData%`, and what the `Dictionary API key source` log
+  line tells the technician — also notes that the legacy `logs/`
+  folder next to the exe is no longer used. The `USO OFFLINE` section's
+  "no GUI error message" warning now cross-references the new log token
+  as the diagnostic of record.
+
 ## [0.4.2] - 2026-05-22
 
 Same-day follow-up to v0.4.1. The v0.4.1 release page attached only
@@ -552,7 +626,8 @@ State of the legacy project before the modernization wave. ~330 commits, ~56k LO
 
 ## Version URLs
 
-[Unreleased]: https://github.com/luca-veronelli-stem/stem-device-manager/compare/v0.4.2...HEAD
+[Unreleased]: https://github.com/luca-veronelli-stem/stem-device-manager/compare/v0.4.3...HEAD
+[0.4.3]: https://github.com/luca-veronelli-stem/stem-device-manager/releases/tag/v0.4.3
 [0.4.2]: https://github.com/luca-veronelli-stem/stem-device-manager/releases/tag/v0.4.2
 [0.4.1]: https://github.com/luca-veronelli-stem/stem-device-manager/releases/tag/v0.4.1
 [0.4.0]: https://github.com/luca-veronelli-stem/stem-device-manager/releases/tag/v0.4.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
 	<!-- Centralized version -->
-	<Version>0.4.2</Version>
-	<FileVersion>0.4.2.0</FileVersion>
-	<AssemblyVersion>0.4.2.0</AssemblyVersion>
+	<Version>0.4.3</Version>
+	<FileVersion>0.4.3.0</FileVersion>
+	<AssemblyVersion>0.4.3.0</AssemblyVersion>
 
 	<!-- Author / company metadata -->
 	<Authors>Michele Pignedoli, Luca Veronelli</Authors>

--- a/Docs/SHIPPED_README.txt
+++ b/Docs/SHIPPED_README.txt
@@ -1,5 +1,5 @@
 ================================================================================
-					   STEM DEVICE MANAGER v0.4.2
+					   STEM DEVICE MANAGER v0.4.3
 							  STEM E.m.s.
 ================================================================================
 
@@ -28,6 +28,11 @@ REQUISITI
 AVVIO
 -----
 Doppio click su: GUI.Windows.exe
+
+IMPORTANTE: i tre file scompattati dallo zip (GUI.Windows.exe,
+appsettings.json, README.txt) devono restare nella stessa cartella.
+Spostare o cancellare appsettings.json fa partire l'app in modalita'
+offline (vedi sezione USO OFFLINE).
 
 NOTA: al primo avvio Windows SmartScreen potrebbe segnalare l'eseguibile
 come "non riconosciuto". Cliccare "Ulteriori informazioni" -> "Esegui comunque".
@@ -137,7 +142,10 @@ seguenti casi:
 - Chiave API non configurata o vuota. ATTENZIONE: questo accade in modo
   silenzioso al primo avvio se non e' stata seguita la procedura di
   CONFIGURAZIONE API DIZIONARI - non viene mostrato alcun messaggio
-  d'errore in GUI; l'unica traccia e' nel file di log sotto logs/.
+  d'errore in GUI. Per diagnosi, controllare il file di log piu' recente
+  (vedi sezione FILE DI LOG): la prima riga "Dictionary API key source"
+  indica quale fonte e' stata effettivamente usata (Empty / AppSettings
+  / ProductionFile / Env).
 
 In modalita' offline:
 - I dizionari di comandi/variabili vengono letti dal file Excel incorporato
@@ -149,6 +157,43 @@ In modalita' offline:
 
 Per forzare l'uso del fallback offline (debug): scollegare la rete o
 impostare DictionaryApi__BaseUrl ad un indirizzo non valido.
+
+
+================================================================================
+							 FILE DI LOG
+================================================================================
+
+A partire dalla v0.4.3 l'applicazione scrive un file di log per ogni
+avvio sotto:
+
+	%LocalAppData%\Stem\DeviceManager\logs\app-<data-ora>.log
+
+(percorso completo tipico:
+C:\Users\<utente>\AppData\Local\Stem\DeviceManager\logs\app-20260522-093609.log)
+
+Per aprire la cartella in Esplora risorse: Win+R, incollare
+"%LocalAppData%\Stem\DeviceManager\logs", invio.
+
+Le prime righe di ogni file di log indicano:
+- timestamp di avvio;
+- la fonte della chiave API risolta a runtime, riga "Dictionary API key
+  source" con uno di questi valori:
+	* Env             -> chiave letta dalla variabile d'ambiente
+					     DictionaryApi__ApiKey;
+	* ProductionFile  -> chiave letta dal file appsettings.Production.json
+					     accanto all'eseguibile;
+	* AppSettings     -> chiave letta da appsettings.json (non dovrebbe
+					     accadere in v0.4.x - il file committato e' vuoto);
+	* Empty           -> nessuna fonte ha fornito un valore. L'app passa
+					     in modalita' offline (Excel embedded).
+
+Quando si segnala un problema al supporto, allegare il file di log piu'
+recente.
+
+NOTA: le versioni precedenti alla v0.4.3 scrivevano i log accanto
+all'eseguibile (cartella logs\ relativa a GUI.Windows.exe). Quel
+percorso non e' piu' usato; i file gia' presenti possono essere
+cancellati a mano.
 
 
 ================================================================================

--- a/GUI.Windows/Diagnostics/ApiKeySourceDetector.cs
+++ b/GUI.Windows/Diagnostics/ApiKeySourceDetector.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
+using Microsoft.Extensions.Configuration.Json;
+
+namespace GUI.Windows.Diagnostics;
+
+/// <summary>
+/// Identifies which configuration provider supplied the live value of
+/// <c>DictionaryApi:ApiKey</c> — used at startup to log a diagnostic line
+/// so technicians can see <i>why</i> the app picked one auth route over
+/// another. The key value itself is never returned, never logged.
+///
+/// Inspects <see cref="IConfigurationRoot.Providers"/> in reverse order
+/// (highest precedence first, matching the runtime lookup order) and
+/// classifies the first provider that yields a non-empty value.
+/// </summary>
+public static class ApiKeySourceDetector
+{
+    private const string Key = "DictionaryApi:ApiKey";
+
+    public static ApiKeySource Detect(IConfiguration configuration)
+    {
+        if (configuration is not IConfigurationRoot root)
+            return ApiKeySource.Unknown;
+
+        foreach (var provider in root.Providers.Reverse())
+        {
+            if (provider.TryGet(Key, out var value) && !string.IsNullOrWhiteSpace(value))
+                return Classify(provider);
+        }
+        return ApiKeySource.Empty;
+    }
+
+    private static ApiKeySource Classify(IConfigurationProvider provider) => provider switch
+    {
+        EnvironmentVariablesConfigurationProvider => ApiKeySource.Env,
+        JsonConfigurationProvider json => IsProductionOverlay(json)
+            ? ApiKeySource.ProductionFile
+            : ApiKeySource.AppSettings,
+        _ => ApiKeySource.Unknown,
+    };
+
+    private static bool IsProductionOverlay(JsonConfigurationProvider json) =>
+        Path.GetFileName(json.Source.Path ?? string.Empty)
+            .Equals("appsettings.Production.json", StringComparison.OrdinalIgnoreCase);
+}
+
+public enum ApiKeySource
+{
+    /// <summary>No provider supplied a non-empty value — the app will use the Excel-only DI path.</summary>
+    Empty,
+
+    /// <summary>The committed <c>appsettings.json</c> next to the exe. Should not happen in v0.4.x+ (key is rotated out of the committed file).</summary>
+    AppSettings,
+
+    /// <summary>The gitignored <c>appsettings.Production.json</c> overlay sitting next to the exe.</summary>
+    ProductionFile,
+
+    /// <summary>The <c>DictionaryApi__ApiKey</c> environment variable.</summary>
+    Env,
+
+    /// <summary>A provider type the detector does not recognise. Configuration was supplied; manual inspection needed.</summary>
+    Unknown,
+}

--- a/GUI.Windows/Diagnostics/StemAppData.cs
+++ b/GUI.Windows/Diagnostics/StemAppData.cs
@@ -1,0 +1,46 @@
+namespace GUI.Windows.Diagnostics;
+
+/// <summary>
+/// Per-user runtime data root for Stem Device Manager, per the STEM
+/// <c>APP_DATA</c> standard (v1.9.0). All file output (logs, future caches,
+/// future credentials) lives under <c>%LocalAppData%\Stem\DeviceManager\</c>
+/// so the shipped single-file <c>.exe</c> doesn't litter its own directory
+/// and the path stays writable regardless of where the technician dropped
+/// the executable.
+///
+/// See <c>shared/standards/APP_DATA.md</c> in the
+/// <see href="https://github.com/luca-veronelli-stem/standards">standards</see>
+/// repo for the convention. v0.4.3 is the first reference adopter; no
+/// migration helper is needed because the previous
+/// <c>AppContext.BaseDirectory/logs/</c> data was per-process session logs
+/// with no longterm value.
+/// </summary>
+internal static class StemAppData
+{
+    private const string CompanySegment = "Stem";
+    private const string AppSegment = "DeviceManager";
+
+    public static string GetAppRoot() =>
+        EnsureDir(Path.Combine(LocalRoot, CompanySegment, AppSegment));
+
+    public static string GetLogsDir() =>
+        EnsureDir(Path.Combine(GetAppRoot(), "logs"));
+
+    public static string GetCacheDir() =>
+        EnsureDir(Path.Combine(GetAppRoot(), "cache"));
+
+    public static string GetCredentialsDir() =>
+        EnsureDir(Path.Combine(GetAppRoot(), "credentials"));
+
+    public static string GetDbDir() =>
+        EnsureDir(Path.Combine(GetAppRoot(), "db"));
+
+    private static string LocalRoot =>
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+    private static string EnsureDir(string path)
+    {
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/GUI.Windows/Forms/Form1.cs
+++ b/GUI.Windows/Forms/Form1.cs
@@ -27,7 +27,7 @@ namespace StemPC
         private readonly BLEManager _bleManager;
         private readonly ILogger<Form1> _logger;
 
-        public const string Software_Version = "0.4.2";
+        public const string Software_Version = "0.4.3";
 
         // Canale hardware corrente selezionato. Le mutazioni vengono propagate a
         // ConnectionManager via SwitchToAsync.

--- a/GUI.Windows/Program.cs
+++ b/GUI.Windows/Program.cs
@@ -73,6 +73,12 @@ namespace GUI.Windows
                 .AddEnvironmentVariables()
                 .Build();
 
+            // Source-of-truth for the Azure dictionary API key (#114). Captured
+            // here so a bench post-mortem can tell at a glance which auth route
+            // the app picked without inspecting env / files by hand. The value
+            // itself is never read or logged -- only the source label.
+            var apiKeySource = Diagnostics.ApiKeySourceDetector.Detect(configuration);
+
             // Configurazione della dependency injection
             var services = new ServiceCollection();
 
@@ -114,6 +120,15 @@ namespace GUI.Windows
 
             // Provider di servizi per dependency injection
             var serviceProvider = services.BuildServiceProvider();
+
+            // #114: log the resolved DictionaryApi:ApiKey source (Empty /
+            // AppSettings / ProductionFile / Env / Unknown). One Information
+            // line on the GUI.Windows.Program category, no key value, just the
+            // label. This is the first log line a bench post-mortem reads
+            // when chasing a silent-Excel-fallback.
+            serviceProvider.GetRequiredService<ILoggerFactory>()
+                .CreateLogger("GUI.Windows.Program")
+                .LogInformation("Dictionary API key source: {Source}", apiKeySource);
 
 #if DEBUG
             // spec-001 T004 (research.md R8): Debug-only shutdown audit.

--- a/GUI.Windows/Program.cs
+++ b/GUI.Windows/Program.cs
@@ -9,7 +9,7 @@ using Services;
 ///*****************************************************************************
 /// @file    Program.cs
 /// @author  Michele Pignedoli, Luca Veronelli
-///@version  0.4.2
+///@version  0.4.3
 /// @date    20/10/2025
 /// @brief   STEM Device Manager Main program body
 ///*****************************************************************************
@@ -40,6 +40,14 @@ using Services;
 ///          README.txt (technician config + procedure) alongside the exe.
 ///          v0.4.1 release shipped exe-only, leaving DictionaryApi:BaseUrl
 ///          null at runtime which silently forced Excel-only mode.
+/// 0.4.3: + Relocate logs to %LocalAppData%\Stem\DeviceManager\logs\ per
+///          the STEM APP_DATA standard v1.9.0 (no more polluting the
+///          install dir; survives read-only Program Files installs).
+///        + Log resolved DictionaryApi:ApiKey source at startup (#114) so
+///          the silent-Excel-fallback chain is one log line away.
+///        + CI: release artifacts now ship as a single zip
+///          (stem-device-manager-<tag>.zip) so a tech can't accidentally
+///          download an incomplete set.
 ///
 /// TODO:
 /// - Completare decodifica faults

--- a/GUI.Windows/Program.cs
+++ b/GUI.Windows/Program.cs
@@ -77,11 +77,11 @@ namespace GUI.Windows
             var services = new ServiceCollection();
 
             // Logging: Debug sink (visible in Output window when running under VS) +
-            // per-process file sink under logs/ so bench sessions and post-mortems can
-            // tail/inspect what happened without a debugger attached.
+            // per-process file sink under %LocalAppData%\Stem\DeviceManager\logs\ so
+            // bench sessions and post-mortems can tail/inspect what happened without a
+            // debugger attached. Location resolves via StemAppData per APP_DATA v1.9.0.
             var logPath = Path.Combine(
-                AppContext.BaseDirectory,
-                "logs",
+                Diagnostics.StemAppData.GetLogsDir(),
                 $"app-{DateTime.Now:yyyyMMdd-HHmmss}.log");
             var fileLoggerProvider = new FileLoggerProvider(logPath);
             services.AddLogging(b => b

--- a/README.md
+++ b/README.md
@@ -99,15 +99,18 @@ Two configurations: `Debug` and `Release`. The device variant (TopLift / Eden / 
 
 ### Single-file publish (field-test executable)
 
-The **recommended** path is the [`Release` GitHub Actions workflow](./.github/workflows/release.yml): pushing a `v*.*.*` tag (after creating the GitHub Release with `gh release create`) automatically builds the self-contained single-file exe and attaches **three artifacts** to the release page:
+The **recommended** path is the [`Release` GitHub Actions workflow](./.github/workflows/release.yml): pushing a `v*.*.*` tag (after creating the GitHub Release with `gh release create`) automatically builds the self-contained single-file exe and attaches a **single zip artifact** to the release page:
 
-| Artifact | Purpose |
-|---|---|
-| `GUI.Windows.exe` | the self-contained app (~80–100 MB) |
-| `appsettings.json` | provides `DictionaryApi:BaseUrl` + `Device:Variant` defaults that the env-var route can't supply |
-| `README.txt` | technician-facing config procedure (Italian — sourced from [`Docs/SHIPPED_README.txt`](./Docs/SHIPPED_README.txt)) |
+```
+stem-device-manager-v0.4.3.zip
+├── GUI.Windows.exe       the self-contained app (~80–100 MB)
+├── appsettings.json      DictionaryApi:BaseUrl + Device:Variant defaults
+└── README.txt            technician-facing config procedure (Italian, from Docs/SHIPPED_README.txt)
+```
 
-The technician downloads all three into the same folder, follows `README.txt` to set the API key (env var or `appsettings.Production.json`), then launches `GUI.Windows.exe`. The workflow can also be re-run on demand via `gh workflow run release.yml -f tag=vX.Y.Z` to refresh artifacts on a previously cut release. The workflow is marked **temporary** until this repo adopts the STEM standards — see [issue #111](https://github.com/luca-veronelli-stem/stem-device-manager/issues/111).
+The technician downloads the zip, extracts all three files into the same folder, follows `README.txt` to set the API key (env var or `appsettings.Production.json`), then launches `GUI.Windows.exe`. The zip shape — instead of three separate uploads — exists so a technician can't accidentally download only the exe and end up on a silent Excel-only fallback (the v0.4.1 → v0.4.2 → v0.4.3 narrative; see [CHANGELOG](./CHANGELOG.md)).
+
+The workflow can also be re-run on demand via `gh workflow run release.yml -f tag=vX.Y.Z` to refresh artifacts on a previously cut release. The workflow is marked **temporary** until this repo adopts the STEM standards — see [issue #111](https://github.com/luca-veronelli-stem/stem-device-manager/issues/111).
 
 For local field tests (or when Actions is unavailable), the same recipe runs by hand. The Excel dictionary (`Resources/Dizionari STEM.xlsx`) is already an embedded resource, so no separate file ships for the fallback:
 
@@ -119,12 +122,17 @@ dotnet publish GUI.Windows/GUI.Windows.csproj `
     -p:PublishSingleFile=true `
     -p:IncludeNativeLibrariesForSelfExtract=true `
     -p:EnableCompressionInSingleFile=true `
-    -o publish/v0.4.2
+    -o publish/v0.4.3
 
-Copy-Item Docs/SHIPPED_README.txt publish/v0.4.2/README.txt
+Copy-Item Docs/SHIPPED_README.txt publish/v0.4.3/README.txt
+
+Compress-Archive `
+    -Path publish/v0.4.3/GUI.Windows.exe,publish/v0.4.3/appsettings.json,publish/v0.4.3/README.txt `
+    -DestinationPath publish/v0.4.3/stem-device-manager-v0.4.3.zip `
+    -Force
 ```
 
-`publish/v0.4.2/` then contains the same three files the workflow uploads. `appsettings.json` is copied there automatically by `dotnet publish` (content files aren't bundled into the single-file exe).
+`publish/v0.4.3/stem-device-manager-v0.4.3.zip` then contains the same three files the workflow uploads. `appsettings.json` is copied into the publish folder automatically by `dotnet publish` (content files aren't bundled into the single-file exe).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ﻿# Stem.Device.Manager
 
-[![Version](https://img.shields.io/badge/version-0.4.2-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.4.3-blue)](./CHANGELOG.md)
 [![.NET](https://img.shields.io/badge/.NET-10.0-512BD4)](https://dotnet.microsoft.com/)
 [![Tests](https://img.shields.io/badge/tests-350%20%2F%20552-brightgreen)](./Tests/)
 [![License](https://img.shields.io/badge/license-Proprietary-red)](#license)

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -45,6 +45,7 @@
     <Compile Remove="Unit\Infrastructure\Protocol\**" />
     <Compile Remove="Unit\Tabs\**" />
     <Compile Remove="Unit\Forms\**" />
+    <Compile Remove="Unit\Diagnostics\**" />
     <Compile Remove="Unit\Core\Models\ButtonIndicatorTests.cs" />
     <!-- ConnectionManager test usa real CanPort/BlePort/SerialPort (Infrastructure.Protocol), Windows-only -->
     <Compile Remove="Unit\Services\Cache\ConnectionManagerTests.cs" />

--- a/Tests/Unit/Diagnostics/ApiKeySourceDetectorTests.cs
+++ b/Tests/Unit/Diagnostics/ApiKeySourceDetectorTests.cs
@@ -1,0 +1,141 @@
+using GUI.Windows.Diagnostics;
+using Microsoft.Extensions.Configuration;
+
+namespace Tests.Unit.Diagnostics;
+
+/// <summary>
+/// Cover the four supported resolution cases plus the precedence ordering
+/// between them. Tests touch real env vars + real temp JSON files to
+/// exercise the same provider types the runtime composition root uses.
+/// </summary>
+public class ApiKeySourceDetectorTests
+{
+    private const string EnvVarName = "DictionaryApi__ApiKey";
+
+    [Fact]
+    public void Detect_NoSource_ReturnsEmpty()
+    {
+        using var temp = new TempDir();
+        File.WriteAllText(Path.Combine(temp.Path, "appsettings.json"), """{ "DictionaryApi": { "ApiKey": "" } }""");
+
+        using (ClearEnvVar())
+        {
+            var config = BuildConfig(temp.Path);
+            Assert.Equal(ApiKeySource.Empty, ApiKeySourceDetector.Detect(config));
+        }
+    }
+
+    [Fact]
+    public void Detect_AppSettingsOnly_ReturnsAppSettings()
+    {
+        using var temp = new TempDir();
+        File.WriteAllText(Path.Combine(temp.Path, "appsettings.json"), """{ "DictionaryApi": { "ApiKey": "from-appsettings" } }""");
+
+        using (ClearEnvVar())
+        {
+            var config = BuildConfig(temp.Path);
+            Assert.Equal(ApiKeySource.AppSettings, ApiKeySourceDetector.Detect(config));
+        }
+    }
+
+    [Fact]
+    public void Detect_ProductionOverlayOnly_ReturnsProductionFile()
+    {
+        using var temp = new TempDir();
+        File.WriteAllText(Path.Combine(temp.Path, "appsettings.json"), """{ "DictionaryApi": { "ApiKey": "" } }""");
+        File.WriteAllText(Path.Combine(temp.Path, "appsettings.Production.json"), """{ "DictionaryApi": { "ApiKey": "from-production" } }""");
+
+        using (ClearEnvVar())
+        {
+            var config = BuildConfig(temp.Path);
+            Assert.Equal(ApiKeySource.ProductionFile, ApiKeySourceDetector.Detect(config));
+        }
+    }
+
+    [Fact]
+    public void Detect_EnvVarOnly_ReturnsEnv()
+    {
+        using var temp = new TempDir();
+        File.WriteAllText(Path.Combine(temp.Path, "appsettings.json"), """{ "DictionaryApi": { "ApiKey": "" } }""");
+
+        using (SetEnvVar("from-env"))
+        {
+            var config = BuildConfig(temp.Path);
+            Assert.Equal(ApiKeySource.Env, ApiKeySourceDetector.Detect(config));
+        }
+    }
+
+    [Fact]
+    public void Detect_EnvVarOverridesProductionFile_ReturnsEnv()
+    {
+        using var temp = new TempDir();
+        File.WriteAllText(Path.Combine(temp.Path, "appsettings.json"), """{ "DictionaryApi": { "ApiKey": "" } }""");
+        File.WriteAllText(Path.Combine(temp.Path, "appsettings.Production.json"), """{ "DictionaryApi": { "ApiKey": "from-production" } }""");
+
+        using (SetEnvVar("from-env"))
+        {
+            var config = BuildConfig(temp.Path);
+            Assert.Equal(ApiKeySource.Env, ApiKeySourceDetector.Detect(config));
+        }
+    }
+
+    [Fact]
+    public void Detect_ProductionFileOverridesAppSettings_ReturnsProductionFile()
+    {
+        using var temp = new TempDir();
+        File.WriteAllText(Path.Combine(temp.Path, "appsettings.json"), """{ "DictionaryApi": { "ApiKey": "from-appsettings" } }""");
+        File.WriteAllText(Path.Combine(temp.Path, "appsettings.Production.json"), """{ "DictionaryApi": { "ApiKey": "from-production" } }""");
+
+        using (ClearEnvVar())
+        {
+            var config = BuildConfig(temp.Path);
+            Assert.Equal(ApiKeySource.ProductionFile, ApiKeySourceDetector.Detect(config));
+        }
+    }
+
+    [Fact]
+    public void Detect_NonConfigurationRoot_ReturnsUnknown()
+    {
+        // IConfiguration that isn't an IConfigurationRoot can't expose providers
+        // -- guard against the upstream contract changing.
+        var section = new ConfigurationBuilder().Build().GetSection("DictionaryApi");
+        Assert.Equal(ApiKeySource.Unknown, ApiKeySourceDetector.Detect(section));
+    }
+
+    private static IConfiguration BuildConfig(string basePath) =>
+        new ConfigurationBuilder()
+            .SetBasePath(basePath)
+            .AddJsonFile("appsettings.json", optional: true)
+            .AddJsonFile("appsettings.Production.json", optional: true, reloadOnChange: false)
+            .AddEnvironmentVariables()
+            .Build();
+
+    private static EnvVarScope SetEnvVar(string value)
+    {
+        Environment.SetEnvironmentVariable(EnvVarName, value);
+        return new EnvVarScope();
+    }
+
+    private static EnvVarScope ClearEnvVar()
+    {
+        Environment.SetEnvironmentVariable(EnvVarName, null);
+        return new EnvVarScope();
+    }
+
+    private sealed class EnvVarScope : IDisposable
+    {
+        public void Dispose() => Environment.SetEnvironmentVariable(EnvVarName, null);
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public TempDir() => Path = Directory.CreateTempSubdirectory("apidetector-test-").FullName;
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Diagnostics + release-shape patch, same-day follow-up to v0.4.2. Bundles three improvements that close out the rough edges surfaced by the v0.4.1 → v0.4.2 silent-Excel-fallback incident — all three target "why did the app silently fall back to Excel?" from different angles. Also the first reference adopter of the new STEM `APP_DATA` standard (v1.9.0, [luca-veronelli-stem/standards#109](https://github.com/luca-veronelli-stem/standards/issues/109)).

Six vertical commits, every commit builds + 909 tests green (350 cross-platform + 559 windows-only — up from 552 windows-only via 7 new `ApiKeySourceDetector` tests):

1. **`feat(diagnostics)`** — `StemAppData` path-resolution helper per `APP_DATA` v1.9.0 convention. Exposes `GetAppRoot()` / `GetLogsDir()` / `GetCacheDir()` / `GetCredentialsDir()` / `GetDbDir()` under `%LocalAppData%\Stem\DeviceManager\`. No consumer yet.
2. **`fix(logs)`** — `Program.cs` swap: `AppContext.BaseDirectory/logs/` → `StemAppData.GetLogsDir()`. Closes the failure mode where logs disappear under read-only install locations (Program Files). v0.4.3 is the first APP_DATA reference adopter; no migration helper (greenfield-adopter pattern — old logs were per-process session files with no longterm value).
3. **`feat(diagnostics)`** — `ApiKeySourceDetector` + Program.cs wiring. One `LogInformation` at startup names the resolved `DictionaryApi:ApiKey` source (`Empty` / `AppSettings` / `ProductionFile` / `Env` / `Unknown`). Never logs the key value. 7 xunit tests cover the 4 cases + precedence + defensive guard. Closes #114.
4. **`ci`** — release workflow swaps three loose-file uploads for `Compress-Archive` + single `gh release upload` of `stem-device-manager-<tag>.zip`. README's "Single-file publish" section + manual recipe updated to match.
5. **`chore(release)`** — version pins 0.4.2 → 0.4.3 across `Directory.Build.props`, `Form1.Software_Version`, `Program.cs` `@version` + history line, README badge.
6. **`docs`** — `Docs/SHIPPED_README.txt` rewritten: header bump, AVVIO `IMPORTANTE` keep-files-together line, new `FILE DI LOG` section documenting the new path + `Dictionary API key source` log token, USO OFFLINE cross-references the new log token. CHANGELOG `[0.4.3]` entry + footnote URLs extended.

## Test plan

### Build + tests
- [x] `dotnet build -c Release` — clean.
- [x] `dotnet test Tests/Tests.csproj -c Release` — 350 / 559 = 909 passing (+7 `ApiKeySourceDetector` tests).
- [x] `git rebase github/main -x "dotnet build -c Release && dotnet test --no-build"` — every commit bisect-safe.

### Smoke matrix (live, post-merge)

When the workflow attaches `stem-device-manager-v0.4.3.zip` to the release page, repeat the v0.4.1 / v0.4.2 verification matrix using the zip's contents:

- [x] Download zip, extract three files into a fresh folder.
- [x] Set `$env:DictionaryApi__ApiKey`, run exe: green "API" chip, Azure HTTP 200s in `%LocalAppData%\Stem\DeviceManager\logs\app-*.log`, **and** the new log line `[INFO] GUI.Windows.Program: Dictionary API key source: Env`.
- [x] Verify legacy `<exe-dir>/logs/` is NOT created.
- [x] Run with `appsettings.Production.json` instead: log line should read `Dictionary API key source: ProductionFile`, chip green API.
- [x] Run with neither: log line reads `Dictionary API key source: Empty`, chip gold "Excel" (no subtext), Excel-only mode.

## Cross-references

- **First reference implementation of [`APP_DATA` v1.9.0](https://github.com/luca-veronelli-stem/standards/blob/v1.9.0/shared/standards/APP_DATA.md)** — `StemAppData` follows the canonical C# pattern from the standard's "Path-resolution helper" section. No formal standards adoption for this repo yet (`state/repos.md` still shows `not yet adopted`); adoption is a separate larger refactor tracked elsewhere.
- **Closes #114** — resolved-key-source startup log line.

## Refs

- Refs #110 (already closed by v0.4.2) — completes the diagnostics arc that started there.
- Refs #94 (still open) — DPAPI / zero-touch remains deferred; v0.4.3 doesn't touch the credential storage shape.
- Refs #111 (still open) — release.yml workflow this PR modifies is the temporary one tracked there.
- Refs `luca-veronelli-stem/standards#109` (closed, shipped in standards v1.9.0).
