### PR TITLE
feat(pcan): add IAsyncDisposable + CTS for clean shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`PCANManager` implements `IAsyncDisposable`.** Background connection
+  monitoring + read loops now share a single `CancellationTokenSource`; on
+  `DisposeAsync()` the CTS is cancelled, both loops exit, and the PCAN
+  channel is uninitialised. Enables consumers (e.g. the upcoming
+  `button-panel-tester` `PcanCanLink`) to shut down cleanly without the
+  loops leaking past application teardown. Internal-only; the
+  `IPcanDriver` abstraction is unchanged.
+
 ---
 
 ## [0.4.3] - 2026-05-22

--- a/Infrastructure.Protocol/Hardware/PCANManager.cs
+++ b/Infrastructure.Protocol/Hardware/PCANManager.cs
@@ -36,11 +36,16 @@ public class CANPacketEventArgs : EventArgs
 /// </code>
 /// </example>
 
-public class PCANManager : IPcanDriver
+public class PCANManager : IPcanDriver, IAsyncDisposable
 {
     private const TPCANHandle Channel = 0x51; // PCAN_USB
     private TPCANBaudrate _currentBaudRate;
     private bool _isConnected;
+
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _monitorTask;
+    private Task? _readTask;
+    private int _disposed;
 
     // Evento per lo stato della connessione
     /// <summary>
@@ -97,9 +102,10 @@ public class PCANManager : IPcanDriver
 
     private void StartConnectionMonitoring()
     {
-        Task.Run(async () =>
+        var token = _cts.Token;
+        _monitorTask = Task.Run(async () =>
         {
-            while (true)
+            while (!token.IsCancellationRequested)
             {
                 try
                 {
@@ -137,14 +143,25 @@ public class PCANManager : IPcanDriver
                         ConnectionStatusChanged?.Invoke(this, true);
                     }
                 }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                    break;
+                }
                 catch (Exception ex)
                 {
                     ErrorOccurred?.Invoke(this, $"Errore nel monitoraggio della connessione: {ex.Message}");
                 }
 
-                await Task.Delay(1000); // Controllo dello stato ogni secondo
+                try
+                {
+                    await Task.Delay(1000, token); // Controllo dello stato ogni secondo
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
             }
-        });
+        }, token);
     }
 
     /// <summary>
@@ -255,7 +272,8 @@ public class PCANManager : IPcanDriver
 
     public void StartReading()
     {
-        Task.Run(ReadCANMessagesAsync);
+        if (_cts.IsCancellationRequested) return;
+        _readTask = Task.Run(ReadCANMessagesAsync, _cts.Token);
     }
 
 
@@ -309,11 +327,19 @@ public class PCANManager : IPcanDriver
 
     private async Task ReadCANMessagesAsync()
     {
-        while (true)
+        var token = _cts.Token;
+        while (!token.IsCancellationRequested)
         {
             if (!_isConnected)
             {
-                await Task.Delay(500); // Attendi finché non viene ristabilita la connessione
+                try
+                {
+                    await Task.Delay(500, token); // Attendi finché non viene ristabilita la connessione
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
                 continue;
             }
 
@@ -342,7 +368,18 @@ public class PCANManager : IPcanDriver
                     ErrorOccurred?.Invoke(this, errorTextB.ToString());
                 }
 
-                await Task.Delay(50); // Riduzione carico CPU
+                try
+                {
+                    await Task.Delay(50, token); // Riduzione carico CPU
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
+            {
+                break;
             }
             catch (Exception ex)
             {
@@ -355,6 +392,38 @@ public class PCANManager : IPcanDriver
     {
         PCANBasic.Uninitialize(Channel);
         _isConnected = false;
+    }
+
+    /// <summary>
+    /// Cancels the background monitoring and read loops, waits for them to
+    /// exit, then closes the PCAN channel. Safe to call multiple times.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+
+        if (!_cts.IsCancellationRequested)
+        {
+            try { _cts.Cancel(); }
+            catch (ObjectDisposedException) { /* already disposed */ }
+        }
+
+        var pending = new List<Task>(2);
+        if (_monitorTask is not null) pending.Add(_monitorTask);
+        if (_readTask is not null) pending.Add(_readTask);
+
+        if (pending.Count > 0)
+        {
+            try { await Task.WhenAll(pending); }
+            catch (OperationCanceledException) { /* expected on cancel */ }
+            catch (Exception ex)
+            {
+                ErrorOccurred?.Invoke(this, $"Errore durante la chiusura dei loop CAN: {ex.Message}");
+            }
+        }
+
+        Disconnect();
+        _cts.Dispose();
     }
 }
 


### PR DESCRIPTION
## Summary

`PCANManager` spawns two `while (true)` background loops in its constructor (connection monitor + message reader) that have no way to stop. This adds `IAsyncDisposable` and a single shared `CancellationTokenSource` so consumers can shut down the driver deterministically.

## Why

The upcoming `button-panel-tester` `PcanCanLink` adapter (spec-002, [button-panel-tester#113](https://github.com/luca-veronelli-stem/button-panel-tester/issues/113)) vendors this file and needs a clean dispose path so its F# composition root can tear the CAN link down without leaking the two background tasks past app teardown. The change is also useful for any future host that restarts the PCAN driver mid-process.

## Changes

- `Infrastructure.Protocol/Hardware/PCANManager.cs`
  - Class now implements `IAsyncDisposable` (interface `IPcanDriver` unchanged).
  - Single private `CancellationTokenSource` shared by `StartConnectionMonitoring()` + `ReadCANMessagesAsync()`.
  - `while (true)` → `while (!token.IsCancellationRequested)` in both loops.
  - Every `await Task.Delay(...)` takes the token and breaks on `OperationCanceledException`.
  - CT-filtered OCE catch precedes the broad `catch (Exception)` so cancellation doesn't surface as an `ErrorOccurred` event.
  - `DisposeAsync()` cancels the CTS, awaits both task handles, calls `Disconnect()`, disposes the CTS. Idempotent via `Interlocked.Exchange`.
- `CHANGELOG.md` — Unreleased entry.

## What's NOT changed

- `IPcanDriver` interface — still no dispose. Adapters that need dispose can cast or hold the concrete handle.
- `FakePcanDriver` (in `Tests/`) — unaffected.
- `CanPort`'s contract with the driver — unchanged.

## Test plan

- [x] `dotnet build Stem.Device.Manager.slnx -c Release -p:EnableWindowsTargeting=true` green.
- [x] `dotnet test Tests/Tests.csproj -c Release` — 350/350 net10.0, 559/559 net10.0-windows.
- [x] Bench validation: not required for this PR (the dispose path is exercised end-to-end by the consumer in spec-002 PR-A; landing here unblocks vendoring).