### PR TITLE
fix(canport): drop ctor IsConnected snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,36 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   loops leaking past application teardown. Internal-only; the
   `IPcanDriver` abstraction is unchanged.
 
+### Fixed
+
+- **`CanPort` no longer snapshots `driver.IsConnected` at construction.**
+  The constructor used to set `_state = driver.IsConnected ? Connected :
+  Disconnected` before subscribing to `ConnectionStatusChanged`. If the
+  driver had already reported `IsConnected = true` (e.g. after
+  `PCANManager`'s eager `PCANBasic.Initialize` inside its own
+  constructor), `_state` was pinned to `Connected` and any subscriber that
+  attached to `StateChanged` after `new CanPort(...)` missed the only
+  state transition the port would ever emit on the cold-start success
+  path. `ConnectAsync` then early-returned at the `State == Connected`
+  guard without firing any `Transition`. Surfaced as a CAN-link wrapper
+  hang in `button-panel-tester` (issue #127): the GUI's CAN status row
+  sat on `Initializing…` indefinitely on plugged-in startup.
+
+  Fix is a one-line change to the constructor: `_state` is unconditionally
+  initialised to `Disconnected`. The first `ConnectAsync` then takes its
+  existing poll loop, observes `_driver.IsConnected = true` on attempt 0,
+  and fires `Transition(Connected)` against the now-subscribed handler.
+  The fail-fast path (driver never reaches Connected → 2 s timeout →
+  `Transition(Error)` + throw) is preserved unchanged. Production
+  consumers in this repo were unaffected (`ConnectionManager.SwitchToAsync`
+  always invokes `ConnectAsync` after constructing the port). Unit tests
+  that asserted the now-removed snapshot contract were rewritten:
+  `Ctor_DriverConnected_InitialStateIsDisconnected` (the renamed inverse
+  of the deleted snapshot test) and `ConnectAsync_AlreadyConnected_NoStateChange`
+  (now a re-Connect idempotency test); the SendAsync/Dispose tests that
+  relied on the ctor-time Connected state now call `await
+  port.ConnectAsync()` explicitly before exercising the contract.
+
 ---
 
 ## [0.4.3] - 2026-05-22

--- a/Infrastructure.Protocol/Hardware/CanPort.cs
+++ b/Infrastructure.Protocol/Hardware/CanPort.cs
@@ -44,9 +44,7 @@ public sealed class CanPort : ICommunicationPort
     {
         ArgumentNullException.ThrowIfNull(driver);
         _driver = driver;
-        _state = (int)(driver.IsConnected
-            ? ConnectionState.Connected
-            : ConnectionState.Disconnected);
+        _state = (int)ConnectionState.Disconnected;
         _driver.PacketReceived += OnDriverPacketReceived;
         _driver.ConnectionStatusChanged += OnDriverConnectionChanged;
     }

--- a/Tests/Unit/Infrastructure/Protocol/CanPortTests.cs
+++ b/Tests/Unit/Infrastructure/Protocol/CanPortTests.cs
@@ -25,14 +25,20 @@ public class CanPortTests
     }
 
     [Fact]
-    public void Ctor_DriverConnected_InitialStateIsConnected()
+    public void Ctor_DriverConnected_InitialStateIsDisconnected()
     {
+        // Post-#127: the constructor no longer snapshots driver.IsConnected.
+        // The initial state is always Disconnected regardless of the driver's
+        // pre-construction state. A subscriber attached after the constructor
+        // must drive `ConnectAsync` (or wait for an external `ConnectionStatusChanged`)
+        // to observe the Connected transition. See `ConnectAsync_DriverAlreadyConnected_TransitionsToConnected`
+        // for the cold-start success path that the snapshot used to mask.
         var driver = new FakePcanDriver { IsConnected = true };
 
         using var port = new CanPort(driver);
 
-        Assert.Equal(ConnectionState.Connected, port.State);
-        Assert.True(port.IsConnected);
+        Assert.Equal(ConnectionState.Disconnected, port.State);
+        Assert.False(port.IsConnected);
     }
 
     [Fact]
@@ -54,8 +60,13 @@ public class CanPortTests
     [Fact]
     public async Task ConnectAsync_AlreadyConnected_NoStateChange()
     {
+        // Idempotency of a second ConnectAsync once the port is already
+        // Connected: no event fires, state stays Connected. The first
+        // ConnectAsync brings the port into the Connected state (post-#127
+        // there is no ctor-time snapshot to short-circuit that).
         var driver = new FakePcanDriver { IsConnected = true };
         using var port = new CanPort(driver);
+        await port.ConnectAsync();
         var stateEvents = new List<ConnectionState>();
         port.StateChanged += (_, s) => stateEvents.Add(s);
 
@@ -68,11 +79,16 @@ public class CanPortTests
     [Fact]
     public async Task ConnectAsync_DriverAlreadyConnected_TransitionsToConnected()
     {
-        // Driver già attivo ma port parte da Disconnected (non realistico in prod,
-        // utile per testare la transizione esplicita).
-        var driver = new FakePcanDriver { IsConnected = false };
+        // Post-#127, this is the canonical cold-start success path: the
+        // driver reports IsConnected = true at construction time (e.g. after
+        // PCANManager's eager PCANBasic.Initialize), and the port's
+        // ConnectAsync poll loop transitions Disconnected → Connecting →
+        // Connected on attempt 0. Subscribers attached after construction
+        // observe both events. Pre-#127 the constructor snapshot pinned the
+        // initial state to Connected and ConnectAsync early-returned without
+        // firing any transition, stranding cold-start subscribers.
+        var driver = new FakePcanDriver { IsConnected = true };
         using var port = new CanPort(driver);
-        driver.IsConnected = true; // driver connette prima di ConnectAsync
         var stateEvents = new List<ConnectionState>();
         port.StateChanged += (_, s) => stateEvents.Add(s);
 
@@ -103,6 +119,7 @@ public class CanPortTests
     {
         var driver = new FakePcanDriver { IsConnected = true };
         using var port = new CanPort(driver);
+        await port.ConnectAsync();
         var stateEvents = new List<ConnectionState>();
         port.StateChanged += (_, s) => stateEvents.Add(s);
 
@@ -146,6 +163,7 @@ public class CanPortTests
     {
         var driver = new FakePcanDriver { IsConnected = true };
         using var port = new CanPort(driver);
+        await port.ConnectAsync();
         var payload = new byte[] { 0x01, 0x02, 0x03 }; // solo 3 byte
 
         await Assert.ThrowsAsync<ArgumentException>(
@@ -157,6 +175,7 @@ public class CanPortTests
     {
         var driver = new FakePcanDriver { IsConnected = true };
         using var port = new CanPort(driver);
+        await port.ConnectAsync();
         // 4 byte arbId + 9 byte dati = 13 totali (massimo CAN = 4+8 = 12)
         var payload = new byte[13];
 
@@ -184,6 +203,7 @@ public class CanPortTests
     {
         var driver = new FakePcanDriver { IsConnected = true };
         using var port = new CanPort(driver);
+        await port.ConnectAsync();
         // arbId = 0x12345678 LE → 78 56 34 12
         // dati  = DE AD BE EF
         var payload = new byte[] { 0x78, 0x56, 0x34, 0x12, 0xDE, 0xAD, 0xBE, 0xEF };
@@ -202,6 +222,7 @@ public class CanPortTests
     {
         var driver = new FakePcanDriver { IsConnected = true };
         using var port = new CanPort(driver);
+        await port.ConnectAsync();
         var payload = new byte[] { 0x01, 0x00, 0x00, 0x00 }; // solo arbId
 
         await port.SendAsync(payload);
@@ -216,6 +237,7 @@ public class CanPortTests
     {
         var driver = new FakePcanDriver { IsConnected = true };
         using var port = new CanPort(driver);
+        await port.ConnectAsync();
         // 4 byte arbId + 8 byte dati = 12 (limite CAN extended)
         var payload = new byte[12];
         payload[0] = 0xFF;
@@ -268,10 +290,11 @@ public class CanPortTests
     // --- StateChanged dagli eventi driver ---
 
     [Fact]
-    public void DriverConnectionStatusChanged_ConnectedToDisconnected_FiresStateChanged()
+    public async Task DriverConnectionStatusChanged_ConnectedToDisconnected_FiresStateChanged()
     {
         var driver = new FakePcanDriver { IsConnected = true };
         using var port = new CanPort(driver);
+        await port.ConnectAsync();
         var stateEvents = new List<ConnectionState>();
         port.StateChanged += (_, s) => stateEvents.Add(s);
 
@@ -282,10 +305,11 @@ public class CanPortTests
     }
 
     [Fact]
-    public void DriverConnectionStatusChanged_SameState_NoEventEmitted()
+    public async Task DriverConnectionStatusChanged_SameState_NoEventEmitted()
     {
         var driver = new FakePcanDriver { IsConnected = true };
         using var port = new CanPort(driver);
+        await port.ConnectAsync();
         var stateEvents = new List<ConnectionState>();
         port.StateChanged += (_, s) => stateEvents.Add(s);
 
@@ -311,10 +335,11 @@ public class CanPortTests
     }
 
     [Fact]
-    public void Dispose_FromConnected_CallsDriverDisconnect()
+    public async Task Dispose_FromConnected_CallsDriverDisconnect()
     {
         var driver = new FakePcanDriver { IsConnected = true };
         var port = new CanPort(driver);
+        await port.ConnectAsync();
 
         port.Dispose();
 
@@ -355,10 +380,11 @@ public class CanPortTests
     }
 
     [Fact]
-    public void Dispose_CalledTwice_IsIdempotent()
+    public async Task Dispose_CalledTwice_IsIdempotent()
     {
         var driver = new FakePcanDriver { IsConnected = true };
         var port = new CanPort(driver);
+        await port.ConnectAsync();
 
         port.Dispose();
         port.Dispose();


### PR DESCRIPTION
## Summary

`CanPort`'s constructor used to snapshot `driver.IsConnected` into `_state` before subscribing to `ConnectionStatusChanged`. When the driver had already flipped to `IsConnected = true` synchronously inside its own constructor (e.g. after `PCANManager`'s eager `PCANBasic.Initialize`), the port's `_state` was pinned to `Connected` before any subscriber could attach. Any handler wired to `port.StateChanged` after `new CanPort(...)` then missed the only state transition the port would ever emit on the cold-start success path, and `ConnectAsync` took its `if (State == Connected) return;` short-circuit at line 73 without firing `Transition(Connecting)` / `Transition(Connected)`.

This PR replaces the snapshot with an unconditional `_state = ConnectionState.Disconnected` in the constructor (+1, -3). The first `ConnectAsync` then routes through its existing poll loop, observes `_driver.IsConnected = true` on attempt 0, and surfaces `Transition(Connected)` to the now-subscribed handler. The fail-fast path (driver never reaches Connected → 2 s timeout → `Transition(Error)` + throw) is preserved unchanged.

## Why

Surfaced downstream in [`button-panel-tester#127`](https://github.com/luca-veronelli-stem/button-panel-tester/issues/127) as a GUI hang on plugged-in startup: the F# `PcanCanLink` adapter (which vendors this file and wires its `StateChanged` handler in its `ensurePort`) never received the `Connected` translation, so the CAN status row sat on `Initializing…` indefinitely. F6 / FR-001 violation, HIGH severity, bench-confirmed.

The fix is correct independent of the downstream symptom: a port should not claim to be `Connected` before any caller has asked it to connect. The snapshot was inherently racy — `IsConnected` can change between construction and any post-construction event subscription, and there is no way for a subscriber to recover the missed transition.

## Changes

- `Infrastructure.Protocol/Hardware/CanPort.cs` — constructor body, **+1, -3**. The subscription wiring on the two following lines is unchanged.
- `Tests/Unit/Infrastructure/Protocol/CanPortTests.cs` — **12 cases updated** (the test list below).
- `CHANGELOG.md` — `Unreleased` `Fixed` entry.

### Test rewrites

- **Renamed/inverted**: `Ctor_DriverConnected_InitialStateIsConnected` → `Ctor_DriverConnected_InitialStateIsDisconnected`. Post-fix, the initial state is always `Disconnected` regardless of the driver's pre-construction `IsConnected`.
- **Recast as idempotency**: `ConnectAsync_AlreadyConnected_NoStateChange` now does a first `ConnectAsync` to reach `Connected`, then verifies that a second `ConnectAsync` is a no-op (no events, state unchanged).
- **`await port.ConnectAsync()` inserted** after construction in 10 cases that previously relied on the ctor-time `Connected` snapshot (3 `Dispose_*`, 2 `DriverConnectionStatusChanged_*`, 5 `SendAsync_*`). Four previously-`void` methods are now `async Task`.
- **Unchanged**: `ConnectAsync_DriverAlreadyConnected_TransitionsToConnected` was already honest about the post-construction transition expectation — it now passes for the right reason (and is effectively the canonical cold-start success regression). `ConnectAsync_DriverNeverConnects_TransitionsToErrorAndThrows` and `MultipleStateCycles_FireAllTransitionEvents` are also unchanged.

## What's NOT changed

- `IPcanDriver` interface — unchanged.
- `FakePcanDriver` (in `Tests/`) — unchanged.
- The `ConnectAsync` poll loop, the `Transition` machinery, and every other `CanPort` method — unchanged.
- Production consumers in this repo. `ConnectionManager.SwitchToAsync` always invokes `ConnectAsync` after constructing the port via DI; no caller reads `port.State` before that. Verified via grep + the full test suite green.

## Test plan

- [x] `dotnet build Stem.Device.Manager.slnx -c Release -p:EnableWindowsTargeting=true` — green, 0 warnings, 0 errors.
- [x] `dotnet test Tests/Tests.csproj -c Release` — **350/350 net10.0, 559/559 net10.0-windows**. Same numbers as `bf60db7` baseline.
- [x] Bench validation downstream: the `button-panel-tester` PR vendoring this diff (PR #134 there) was bench-tested against a PEAK PCAN-USB Opto-Decoupled (IPEH-002022) — cold-start `Initializing → Connected ≤ 2 s` on plugged-in startup; fail-fast `Error(Recoverable, _)` preserved on adapter-absent startup.

Refs button-panel-tester#127.