### PR TITLE
fix(spark): settle before reboot so ECUs commit their firmware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-06-17
+
 ### Added
 
 - **`PCANManager` implements `IAsyncDisposable`.** Background connection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,25 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **SPARK batch firmware update: settle before the reboot so ECUs commit
+  their image.** The batch fired `CMD_RESTART_MACHINE` ~3 ms after the
+  `CMD_END_PROCEDURE` reply. `END` triggers the target board's image
+  finalize (close flash session, write the validity marker, switch the boot
+  vector), which takes a few seconds; rebooting mid-finalize left the ECU
+  image invalid and the board came up at `v0.0.0.0` (bricked). The HMI
+  application/images survived — the HMI is the board the soft restart
+  reboots — but the ECUs (Motor1/Motor2/Rostrum) did not.
+  `SparkBatchUpdateService` now waits a configurable **commit settle**
+  (default 5 s, constructor-injectable, no-op at `TimeSpan.Zero` so tests
+  don't real-sleep): one after the last block before `END` (per area), and
+  one after `END` before the single end-of-batch `RESTART_MACHINE`.
+  Bench-validated on Egicon SN 2225998 with two consecutive clean full
+  5-area batches (no battery pull). New docs:
+  [`Docs/SPARK_BATCH_COMMANDS.md`](Docs/SPARK_BATCH_COMMANDS.md) (exact
+  command sequence, first-page erase wait, settle) and
+  [`Docs/SPARK_BATCH_OPERATOR_NOTES.md`](Docs/SPARK_BATCH_OPERATOR_NOTES.md)
+  (file identification by work-code, what's normal during a flash, recovery).
+
 - **`CanPort` no longer snapshots `driver.IsConnected` at construction.**
   The constructor used to set `_state = driver.IsConnected ? Connected :
   Disconnected` before subscribing to `ConnectionStatusChanged`. If the

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
 	<!-- Centralized version -->
-	<Version>0.4.3</Version>
-	<FileVersion>0.4.3.0</FileVersion>
-	<AssemblyVersion>0.4.3.0</AssemblyVersion>
+	<Version>0.4.4</Version>
+	<FileVersion>0.4.4.0</FileVersion>
+	<AssemblyVersion>0.4.4.0</AssemblyVersion>
 
 	<!-- Author / company metadata -->
 	<Authors>Michele Pignedoli, Luca Veronelli</Authors>

--- a/Docs/SPARK_BATCH_COMMANDS.md
+++ b/Docs/SPARK_BATCH_COMMANDS.md
@@ -1,0 +1,251 @@
+# SPARK Batch Firmware Update — Command Sequence (excluding bootloader)
+
+The exact STEM-protocol commands the application sends to flash a SPARK over BLE
+through the **SPARK Firmware Update** tab (`GUI.Windows/Tabs/Spark_FirmwareUpdate_WF_Tab.cs`
+→ `Services/Boot/SparkBatchUpdateService.cs` → `Services/Boot/BootService.cs`).
+
+**Scope:** every area **except** "Bootloader HMI" — i.e. HMI application, HMI Images,
+Motor 1, Motor 2, Rostrum. Bench-validated on Egicon SN 2225998, bundle 8.2.0.1
+(2026-06-15 / 2026-06-17).
+
+> All wire-level layering (Transport CRC16, Network chunking, NetInfo, senderId
+> endianness) is in [`PROTOCOL.md`](PROTOCOL.md). This document is the boot/batch
+> command layer on top of it. For operator-facing guidance (file identification,
+> what's normal during a flash, recovery), see
+> [`SPARK_BATCH_OPERATOR_NOTES.md`](SPARK_BATCH_OPERATOR_NOTES.md).
+
+### Boot-entry observations (expected, benign)
+
+- **One `0xFF` byte on the first `START` only.** The first `CMD_START_PROCEDURE` transitions the
+  device from its application into the bootloader; that transition takes **~3.5 s** and the device
+  emits a single `0xFF` notification (logged as `Discarded short Ble frame: 1 bytes … FF` — a valid
+  STEM frame needs ≥6 bytes, so the decoder drops it). Subsequent areas' `START`s are answered in
+  ~0.1 s with **no** `0xFF`, because the device stays in the bootloader for the whole batch (only the
+  final `RESTART_MACHINE` leaves it). So the `0xFF` is a one-shot boot-entry marker, not a reply.
+- **`result 0x00`** on every `0x8007` page ack = success (§3.1).
+
+---
+
+## 1. Areas, order, recipient
+
+The batch runs the selected areas in canonical order (`Core/Models/SparkFirmwareArea.cs`,
+`SparkAreas.All`). **Every area is addressed to the HMI recipient `0x000702C1`** — the HMI
+is the machine's update orchestrator and stages/forwards each image to its target board.
+
+| Order | Area | File (bundle 8.2.0.1) | Recipient | fwType¹ | Size (B) | Blocks² |
+|---|---|---|---|---|---|---|
+| 1 | HMI application | `WORKCODE_HMI_RSC.bin` | `0x000702C1` | `0x5F45` | 664 576 | 649 |
+| 2 | HMI Images | `IMAGES_HMI_RSC.bin` | `0x000702C1` | `0x5345` | 5 486 112 | 5 358 |
+| 3 | Motor 1 (right) | `WEMOTOR1.bin` | `0x000702C1` | `0x5F45` | 47 104 | 46 |
+| 4 | Motor 2 (left) | `WEMOTOR2.bin` | `0x000702C1` | `0x5F45` | 47 104 | 46 |
+| 5 | Rostrum | `WEROSTRO.bin` | `0x000702C1` | `0x5F45` | 24 576 | 24 |
+
+¹ `fwType` is read from **firmware-file bytes 14–15** (`fwType = (file[15] << 8) | file[14]`),
+not assigned by area; values above are what the bench files carry. The file header also
+carries an ASCII work-code identity around bytes 10–17 (e.g. Rostrum = `WCODE_E1`) that the
+HMI uses to route the image to the correct board.
+² `Blocks = ceil(Size / 1024)`.
+
+---
+
+## 2. Application-layer commands used
+
+Codes are 16-bit `(cmdInit << 8) | cmdOpt`. A reply sets bit 7 of `cmdInit` (i.e. `0x80 | code`).
+
+| Command | Code | App payload (request) | Reply code | Source |
+|---|---|---|---|---|
+| `CMD_START_PROCEDURE` | `0x0005` | *(empty)* | `0x8005` | `BootService.StartBootAsync` |
+| `CMD_PROGRAM_BLOCK` | `0x0007` | 14-byte header + 1024-byte block (§3) | `0x8007` | `BootService.SendAllBlocks` |
+| `CMD_END_PROCEDURE` | `0x0006` | *(empty)* | `0x8006` | `BootService.EndBootAsync` |
+| `CMD_RESTART_MACHINE` | `0x000A` | *(empty)* | `0x800A` | `BootService.RestartAsync` |
+
+Acceptance rule: `BootService.MatchesReply` accepts a reply when `cmdInit == 0x80` **and**
+`cmdOpt` equals the request's low byte. The reply payload is **not** inspected (see §3.1).
+
+---
+
+## 3. `CMD_PROGRAM_BLOCK` payload layout
+
+Built by `BootService.BuildProgramBlockPayload`. 14-byte header followed by one 1024-byte
+firmware block:
+
+```
+offset  0..1   fwType        big-endian   = (file[15]<<8)|file[14]   e.g. 5F 45
+offset  2..5   pageNum       big-endian   0,1,2,…  (one per block, from 0)
+offset  6..9   pageSize      big-endian   always 0x00000400 (1024)
+offset 10..13  reserved                   0x00 0x00 0x00 0x00
+offset 14..    block(1024)                firmware bytes; LAST block 0xFF-padded to 1024
+```
+
+- `pageSize` is **always 1024**, even for the final (short) block — the tail is `0xFF`-padded.
+- Total app-layer payload per block = `2 + 4 + 4 + 4 + 1024` = **1038 bytes** → chunked into
+  ~11 BLE frames of ≤98 data bytes each (`PROTOCOL.md §4.3`).
+
+### 3.1 `0x8007` reply ("Aggiorna pagina bootloader risposta")
+
+15 bytes, echoing the header plus a trailing result region:
+
+```
+fwType(2) | pageNum(4) | pageSize(4 = 00 00 04 00) | result(5 bytes)
+```
+
+On every acknowledged block observed on the bench the result region was **all `0x00`**
+(success). The host does **not** read this byte today — a block counts as done the moment a
+`0x8007` reply with the matching low byte returns. Hardening this is a separate follow-up.
+
+---
+
+## 4. Per-area sequence
+
+`SparkBatchUpdateService.RunAreaAsync`:
+
+```
+CMD_START_PROCEDURE        → 0x000702C1     (await 0x8005)
+CMD_PROGRAM_BLOCK × Blocks → 0x000702C1     (each awaits its 0x8007; pageNum 0…Blocks-1)
+‹settle: wait 5 s›                          (after last block, before END — no wire traffic)
+CMD_END_PROCEDURE          → 0x000702C1     (await 0x8006)
+```
+
+There is **no per-area `RESTART_MACHINE`** — restart is hoisted to the end of the whole batch
+(§5). Retry budget: first block 60 attempts (rides out the device-side flash erase, §4.1), all
+other commands 3 attempts; 4000 ms reply timeout (`BootService` defaults).
+
+### 4.1 Time to wait between `START_PROCEDURE` and the first page
+
+After `CMD_START_PROCEDURE` is acknowledged (`0x8005`), the target board **erases the flash area**
+it is about to program. The erase takes time (from a few hundred ms up to several seconds,
+depending on area size), and the bootloader does **not** acknowledge the first `CMD_PROGRAM_BLOCK`
+until the erase has finished.
+
+The host does **not** insert a fixed delay here. Page 0 is sent immediately and **retried with a
+much larger budget** than the rest, so the wait is *adaptive* — it lasts exactly as long as the
+erase, no more:
+
+| Block | Retry budget | Per-attempt reply timeout | Max wait |
+|---|---|---|---|
+| Page 0 (first of **each area**) | 60 attempts (`firstBlockRetryBudget`) | 4000 ms | ~240 s |
+| Pages 1…N | 3 attempts (`retryBudget`) | 4000 ms | ~12 s |
+
+Each unacknowledged attempt re-sends page 0 and waits up to 4 s for a reply; the loop repeats (up
+to ~240 s) until the bootloader finishes erasing and acks. The moment it acks, programming runs at
+full speed — pages 1…N use the short 3-attempt budget, because slowness past the erase is not
+expected and a dead link should fail fast.
+
+This is why the logs show **one or two early `Retrying ProgramBlock` lines (page 0/1) in every
+run** — that is page 0 being re-sent while the flash erases, **not** an error. The first-block
+budget resets for **each area** (`pageNum` restarts at 0 per area), so every area rides out its own
+erase. The ~240 s ceiling is ~2× the worst measured area-erase time — enough margin to never abort
+a healthy erase, without hanging forever on a truly dead link.
+
+> A multi-second `START → first page` gap seen in a **manual** (human-paced) flash is incidental —
+> the operator clicking "Upload" after the Start dialog — and is **not** a required delay. The retry
+> budget is the real mechanism; sending page 0 immediately is correct because it is retried until
+> the erase completes. (Contrast with the `END → RESTART` settle in §6, which *is* a required wait
+> because nothing else gates it.)
+
+---
+
+## 5. Whole-batch sequence (excluding bootloader)
+
+`SparkBatchUpdateService.ExecuteAsync` — areas in canonical order, single restart at the end:
+
+```
+── Area 1  HMI application ──────────────────────────────
+   START_PROCEDURE              → 0x000702C1
+   PROGRAM_BLOCK × 649          → 0x000702C1   (pageNum 0…648)
+   ‹settle 5 s›
+   END_PROCEDURE                → 0x000702C1
+── Area 2  HMI Images ───────────────────────────────────
+   START_PROCEDURE              → 0x000702C1
+   PROGRAM_BLOCK × 5358         → 0x000702C1   (pageNum 0…5357)
+   ‹settle 5 s›
+   END_PROCEDURE                → 0x000702C1
+── Area 3  Motor 1 ──────────────────────────────────────
+   START_PROCEDURE              → 0x000702C1
+   PROGRAM_BLOCK × 46           → 0x000702C1
+   ‹settle 5 s›
+   END_PROCEDURE                → 0x000702C1
+── Area 4  Motor 2 ──────────────────────────────────────
+   START_PROCEDURE              → 0x000702C1
+   PROGRAM_BLOCK × 46           → 0x000702C1
+   ‹settle 5 s›
+   END_PROCEDURE                → 0x000702C1
+── Area 5  Rostrum ──────────────────────────────────────
+   START_PROCEDURE              → 0x000702C1
+   PROGRAM_BLOCK × 24           → 0x000702C1
+   ‹settle 5 s›
+   END_PROCEDURE                → 0x000702C1
+── End of batch ─────────────────────────────────────────
+   ‹settle 5 s›
+   RESTART_MACHINE              → 0x000702C1   (single, await 0x800A)
+```
+
+`pageNum` **resets to 0 at the start of each area**. Restart is sent **once**, only after the
+last area's `END_PROCEDURE` succeeds.
+
+**Abort path:** if any area fails (no reply after the retry budget), the batch throws and
+**no `RESTART_MACHINE` is sent** — a half-flashed device is not auto-rebooted; recovery is
+operator-driven.
+
+---
+
+## 6. The commit settle (required — bench finding 2026-06-15)
+
+The two `‹settle 5 s›` waits are **not** cosmetic and are the difference between a working and a
+bricking ECU flash. `CMD_END_PROCEDURE` makes the target board finalize the freshly-written
+image (close the flash session, write the validity marker, switch the boot vector); that takes
+a few seconds. Firing `RESTART_MACHINE` immediately after the `0x8006` reply reboots the board
+**mid-finalize**, leaving the image invalid → the ECU comes up at `v0.0.0.0`.
+
+- A manual flash that worked left **~3.4 s** between the `END` reply and `RESTART`.
+- The unguarded batch fired them **~3 ms** apart and bricked the ECU.
+
+`SparkBatchUpdateService` reinstates the window: `_postBlocksSettle` (after the last block,
+before `END`) and `_postEndSettle` (after `END`, before `RESTART`), both default **5 s** and
+constructor-configurable. They emit no wire traffic. A device-readiness poll would be the
+longer-term replacement for fixed delays.
+
+---
+
+## 7. How each command goes on the wire (summary)
+
+Per `PROTOCOL.md`. For BLE each application command is wrapped:
+
+```
+Application Layer : [ cmdInit(1) | cmdOpt(1) | payload(N) ]
+Transport  Layer  : [ 0x00 | senderId(4 BE)=0x00000008 | lPack(2 BE) | AL | CRC16(2 BE) ]
+Network    Layer  : [ NetInfo(2 LE) | recipientId(4 LE)=C1 02 07 00 | chunk(≤98) ] × ceil(len/98)
+```
+
+- **senderId** = `Device:SenderId` from `appsettings.json` (default `8`), big-endian on the wire.
+- **recipientId** = `0x000702C1`, little-endian in the BLE frame → bytes `C1 02 07 00`.
+- **CRC16** = Modbus (init `0xFFFF`, poly `0xA001`) over `[TL header + AL]`, big-endian; **not**
+  validated on receive today.
+- **NetInfo** carries `remainingChunks | setLength | packetId(1..7) | version`; the last chunk
+  has `remainingChunks == 0`.
+
+---
+
+## 8. Concrete example — Rostrum area (bench log app-20260615-174322, with the settle fix)
+
+```
+SPARK area start: Rostrum (24576 bytes) → recipient 000702C1
+TX START_PROCEDURE → 000702C1            →  RX 8005
+TX PROGRAM_BLOCK × 24 → 000702C1         →  RX 8007 × 24   (pageNum 0…23, all result=0x00)
+SPARK settle: waiting 5.0s after last block, before END
+TX END_PROCEDURE → 000702C1              →  RX 8006
+SPARK settle: waiting 5.0s after END, before RESTART (ECU commit window)
+TX RESTART_MACHINE → 000702C1            →  RX 800A   (~5 s after the 8006 reply)
+SPARK batch end: all selected areas completed
+```
+
+Sample frames (Rostrum, BLE; `PROGRAM_BLOCK` chunk 1 of 11 shown):
+
+```
+TX START_PROCEDURE   : <NetInfo> C1 02 07 00 | 00 00 00 00 00 08 00 02 00 05 <crc>
+                                   └recipient┘   └─ TL: crypt|sender|lPack ─┘ └AL 00 05┘
+RX 8005              : … from 000702C1, payload=00
+TX PROGRAM_BLOCK     : … 00 07 | 5F 45 | 00 00 00 00 | 00 00 04 00 | 00 00 00 00 | <1024 block…>
+                              cmd   fwType   pageNum=0   pageSize=1024  reserved
+RX 8007              : … from 000702C1, payload=5F45 00000000 00000400 00 00 00 00 00
+```

--- a/Docs/SPARK_BATCH_OPERATOR_NOTES.md
+++ b/Docs/SPARK_BATCH_OPERATOR_NOTES.md
@@ -1,0 +1,121 @@
+# SPARK Batch Firmware Update — Operator Notes
+
+Practical notes for whoever runs the SPARK firmware update from the **SPARK Firmware Update** tab.
+For the exact protocol commands see [`SPARK_BATCH_COMMANDS.md`](SPARK_BATCH_COMMANDS.md); for the
+full official procedure (USB, Bluetooth module, calibration) see
+[`SPARK_UPDATE_FW.md`](SPARK_UPDATE_FW.md).
+
+Bench-validated 2026-06-15 / 2026-06-17 on Egicon SN 2225998 (two consecutive clean full-batch runs).
+
+---
+
+## 1. What this tab flashes — and what it does NOT
+
+Over BLE, in one batch: **HMI application, HMI Images, Motor 1, Motor 2, Rostrum.**
+
+It does **not** flash:
+- **The Bluetooth module** (`BGM220…` file) — that's FASE 1, done with Silicon Labs'
+  **Simplicity Connect** mobile app (`.gbl`/`.bin`), not this tool. The file carries no STEM
+  work-code header and is not a batch area.
+- **Bootloader HMI** — separate step (see `SPARK_UPDATE_FW.md`).
+
+---
+
+## 2. Pick the right file — DO NOT trust the filename ⚠️
+
+Firmware filenames are **ambiguous**: a cloud download can produce two files that differ only by a
+`(1)` suffix (Windows dedup), and that suffix does **not** tell you which board. The authoritative
+identifier is the **work-code string in the file header** (ASCII, ~bytes 10–17). The tool logs it on
+file selection: `SPARK batch file: <area> … header=…`.
+
+| Work-code | Board / area | Example file (bundle `Spark_08.03`) | Size |
+|---|---|---|---|
+| `WCODE_HMI` | HMI application | `DIS0016201_1_08.02.00.01.bin` | 664 576 |
+| `IMAGES_HMI` | HMI Images | `DIS0016201_1_08.02.00.01 (1).bin` | 672 800 |
+| `WCODE_E2` | **Motor 1 (right)** | `DIS0016204_1_04.01.00.00.bin` | 47 104 |
+| `WCODE_E3` | **Motor 2 (left)** | `DIS0016204_1_04.01.00.00 (1).bin` | 47 104 |
+| `WCODE_E1` | Rostrum | `DIS0016202_1_03.01.00.00.bin` | 24 576 |
+
+The two **motor** files are the trap: same name except `(1)`, both 47 104 B — only the work-code
+(`E2` vs `E3`) distinguishes them. The HMI app/images pair has the same trap. **Always confirm by
+work-code, not by filename or by the `(1)`.** (E1 = Rostrum, E2 = Motor 1, E3 = Motor 2.)
+
+---
+
+## 3. What's normal during a flash (don't be alarmed)
+
+All of the following are expected and were present on every successful run:
+
+- **A single `FF` byte / `Discarded short Ble frame: 1 bytes … Bytes: FF`** right after the very
+  first `START`. It's the device entering bootloader mode **once**; harmless. Appears only on the
+  first area, never again in the batch.
+- **The first `START` takes ~3.5 s** (later areas ~0.1 s). That's the one-time
+  application→bootloader transition; the device then stays in the bootloader for the whole batch.
+- **One or two early `Retrying ProgramBlock`** at the **start of each area**. That's the first page
+  waiting out the device-side flash erase (the bootloader only acks once the flash is ready) — not
+  an error. See `SPARK_BATCH_COMMANDS.md` §4.1.
+- **`SPARK settle: waiting 5.0s …` lines** — the deliberate commit waits (see §5). One per area
+  before `END`, plus one before the final reboot.
+- **`result 0x00`** on every page acknowledgement = success.
+
+A genuine problem looks like an `[ERRO] SPARK area failed: … at phase …` line and a popup.
+
+---
+
+## 4. How long it takes
+
+~1 second per 1 KB block, plus the settles.
+
+- Full 5-area batch with the **~672 KB test** HMI Images: **~25–27 min**.
+- The **full ~5.5 MB production** HMI Images alone is ~5 358 blocks ≈ **~90 min** — plan accordingly
+  if you flash the real images.
+
+---
+
+## 5. Why the reboot waits at the end (the commit settle)
+
+After `END_PROCEDURE` the target board **finalizes** its freshly-written image (closes the flash
+session, writes the validity marker, switches the boot vector) — this takes a few seconds. The tool
+waits **5 s after `END` before the reboot**, plus 5 s after each area's last block, so the commit
+completes.
+
+**This wait is load-bearing.** Without it the batch rebooted the ECU mid-finalize and **bricked it
+to `v0.0.0.0`**. That was the bug; the settle is the fix. So the batch is intentionally a little
+slower at each boundary — that's the safety window, not a hang.
+
+---
+
+## 6. If a flash fails
+
+- The batch **stops at the failing area and does NOT reboot** — a half-flashed device must not be
+  auto-rebooted, so it's left in a known state for recovery.
+- A bricked / unfinished ECU reports **`v0.0.0.0`** and is unresponsive.
+- **Recover via USB**: re-flash the affected board from the USB procedure
+  (`WORKCODE.hex` / `WEMOTORx.hex` / `WEROSTRO.hex`, see `SPARK_UPDATE_FW.md` FASE 2–5). USB uses the
+  HMI's own programmer and is the reliable fallback.
+
+---
+
+## 7. Running alongside another app that needs the CAN bus
+
+By default the tool opens the **PCAN-USB (CAN)** bus at boot. To leave the bus free for another
+process, disable CAN auto-start:
+
+- `appsettings.json` → `"Can": { "AutoStart": false }`, **or**
+- environment variable `Can__AutoStart=false` at launch.
+
+With auto-start off, the CAN bus is untouched until you explicitly select the CAN channel in the
+app. **SPARK updates are BLE**, so this does not affect them — confirmed by a full 27-minute batch
+run with CAN auto-start disabled and the bus left free the whole time.
+
+---
+
+## 8. Quick checklist
+
+1. Connect to SPARK over BLE; confirm with a version read (App Layer tab).
+2. In the SPARK Firmware Update tab, assign each file to its area **by work-code** (§2).
+3. Start the batch. Expect the §3 artifacts; watch for `SPARK area done` per area.
+4. Let it run to `SPARK batch end: all selected areas completed` + the final reboot — **do not close
+   the app mid-batch.**
+5. After reboot, verify every board's version on the device (all 3 ECUs + HMI).
+6. On any failure: don't reboot manually; recover the affected board via USB (§6).

--- a/Services/Boot/SparkBatchUpdateService.cs
+++ b/Services/Boot/SparkBatchUpdateService.cs
@@ -77,13 +77,34 @@ public sealed class SparkBatchUpdateService
 {
     private readonly IBootService _boot;
     private readonly ILogger<SparkBatchUpdateService> _logger;
+    private readonly TimeSpan _postBlocksSettle;
+    private readonly TimeSpan _postEndSettle;
+
+    /// <summary>Default settle after the last block, before <c>CMD_END_PROCEDURE</c>.</summary>
+    public static readonly TimeSpan DefaultPostBlocksSettle = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Default settle after <c>CMD_END_PROCEDURE</c>, before the end-of-batch
+    /// <c>CMD_RESTART_MACHINE</c>. Bench (2026-06-15): the ECU finalizes its freshly-written
+    /// image on END (closes the flash session, writes the validity marker, switches the boot
+    /// vector). Rebooting before that finishes leaves the image invalid → the ECU comes up at
+    /// v0.0.0.0. A manual flash that worked left ~3.4 s between the END reply and RESTART; the
+    /// automated batch fired them ~3 ms apart and bricked the ECU. These settles reinstate that
+    /// commit window. Tunable; a device-readiness poll would be the longer-term replacement.
+    /// </summary>
+    public static readonly TimeSpan DefaultPostEndSettle = TimeSpan.FromSeconds(5);
 
     public SparkBatchUpdateService(
-        IBootService boot, ILogger<SparkBatchUpdateService>? logger = null)
+        IBootService boot,
+        ILogger<SparkBatchUpdateService>? logger = null,
+        TimeSpan? postBlocksSettle = null,
+        TimeSpan? postEndSettle = null)
     {
         ArgumentNullException.ThrowIfNull(boot);
         _boot = boot;
         _logger = logger ?? NullLogger<SparkBatchUpdateService>.Instance;
+        _postBlocksSettle = postBlocksSettle ?? DefaultPostBlocksSettle;
+        _postEndSettle = postEndSettle ?? DefaultPostEndSettle;
     }
 
     /// <summary>Raised when an area is about to start uploading.</summary>
@@ -182,7 +203,24 @@ public sealed class SparkBatchUpdateService
     {
         await StartBootAsync(def, ct).ConfigureAwait(false);
         await UploadBlocksAsync(item, def, ct).ConfigureAwait(false);
+        await SettleAsync(_postBlocksSettle, "after last block, before END", def, ct)
+            .ConfigureAwait(false);
         await EndBootAsync(def, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Waits out the device-side commit window between boot steps (bench 2026-06-15;
+    /// see <see cref="DefaultPostEndSettle"/>). No-op when the configured settle is zero,
+    /// so tests can disable the wait.
+    /// </summary>
+    private async Task SettleAsync(
+        TimeSpan settle, string why, SparkAreaDefinition def, CancellationToken ct)
+    {
+        if (settle <= TimeSpan.Zero) return;
+        _logger.LogInformation(
+            "SPARK settle: waiting {Seconds:0.0}s {Why} ({Area})",
+            settle.TotalSeconds, why, def.DisplayName);
+        await Task.Delay(settle, ct).ConfigureAwait(false);
     }
 
     private async Task RestartAtEndOfBatchAsync(CancellationToken ct)
@@ -193,6 +231,8 @@ public sealed class SparkBatchUpdateService
             hmiRecipient);
         try
         {
+            await SettleAsync(_postEndSettle, "after END, before RESTART (ECU commit window)",
+                SparkAreas.Get(SparkFirmwareArea.HmiApplication), ct).ConfigureAwait(false);
             await _boot.RestartAsync(hmiRecipient, ct).ConfigureAwait(false);
         }
         catch (BootSessionLostException ex)

--- a/Tests/Integration/Boot/SparkBleStabilizationTests.cs
+++ b/Tests/Integration/Boot/SparkBleStabilizationTests.cs
@@ -395,7 +395,7 @@ public class SparkBleStabilizationTests
         for (int run = 0; run < 10; run++)
         {
             var fake = new FakeBootService();
-            var orchestrator = new SparkBatchUpdateService(fake);
+            var orchestrator = new SparkBatchUpdateService(fake, postBlocksSettle: TimeSpan.Zero, postEndSettle: TimeSpan.Zero);
             var completed = new List<SparkFirmwareArea>();
             orchestrator.AreaCompleted += (_, def) => completed.Add(def.Area);
 
@@ -421,7 +421,7 @@ public class SparkBleStabilizationTests
             {
                 UploadBlocksFailsAtCall = 2,
             };
-            var orchestrator = new SparkBatchUpdateService(fake);
+            var orchestrator = new SparkBatchUpdateService(fake, postBlocksSettle: TimeSpan.Zero, postEndSettle: TimeSpan.Zero);
             var completed = new List<SparkFirmwareArea>();
             orchestrator.AreaCompleted += (_, def) => completed.Add(def.Area);
 

--- a/Tests/Unit/Services/Boot/SparkBatchUpdateServiceTests.cs
+++ b/Tests/Unit/Services/Boot/SparkBatchUpdateServiceTests.cs
@@ -16,7 +16,8 @@ public class SparkBatchUpdateServiceTests
     [Fact]
     public async Task ExecuteAsync_NullItems_Throws()
     {
-        var orchestrator = new SparkBatchUpdateService(new FakeBootService());
+        var orchestrator = new SparkBatchUpdateService(
+            new FakeBootService(), postBlocksSettle: TimeSpan.Zero, postEndSettle: TimeSpan.Zero);
         await Assert.ThrowsAsync<ArgumentNullException>(
             () => orchestrator.ExecuteAsync(null!));
     }
@@ -25,7 +26,7 @@ public class SparkBatchUpdateServiceTests
     public async Task ExecuteAsync_EmptyItems_DoesNothing()
     {
         var fake = new FakeBootService();
-        var orchestrator = new SparkBatchUpdateService(fake);
+        var orchestrator = new SparkBatchUpdateService(fake, postBlocksSettle: TimeSpan.Zero, postEndSettle: TimeSpan.Zero);
 
         await orchestrator.ExecuteAsync([]);
 
@@ -36,7 +37,7 @@ public class SparkBatchUpdateServiceTests
     public async Task ExecuteAsync_AllAreas_RunsInCanonicalOrder()
     {
         var fake = new FakeBootService();
-        var orchestrator = new SparkBatchUpdateService(fake);
+        var orchestrator = new SparkBatchUpdateService(fake, postBlocksSettle: TimeSpan.Zero, postEndSettle: TimeSpan.Zero);
         // All areas share the HMI recipient, so order is observed through the
         // firmware payload each area uploads: one distinct byte per area.
         var fwByArea = SparkAreas.All.ToDictionary(
@@ -70,7 +71,7 @@ public class SparkBatchUpdateServiceTests
     public async Task ExecuteAsync_Subset_RunsOnlySelectedInCanonicalOrder()
     {
         var fake = new FakeBootService();
-        var orchestrator = new SparkBatchUpdateService(fake);
+        var orchestrator = new SparkBatchUpdateService(fake, postBlocksSettle: TimeSpan.Zero, postEndSettle: TimeSpan.Zero);
         byte[] imagesFw = [1];
         byte[] rostrumFw = [2];
         var items = new List<SparkBatchItem>
@@ -97,7 +98,7 @@ public class SparkBatchUpdateServiceTests
         // per-ECU addressing gets no reply over BLE.
         const uint HmiRecipient = 0x000702C1u;
         var fake = new FakeBootService();
-        var orchestrator = new SparkBatchUpdateService(fake);
+        var orchestrator = new SparkBatchUpdateService(fake, postBlocksSettle: TimeSpan.Zero, postEndSettle: TimeSpan.Zero);
         var items = SparkAreas.All
             .Select(a => new SparkBatchItem(a.Area, Fw))
             .ToList();
@@ -114,7 +115,7 @@ public class SparkBatchUpdateServiceTests
         // StartBoot call = Motor1 in canonical order (BootloaderHmi,
         // HmiApplication, HmiImages, Motor1, Motor2, Rostrum).
         var fake = new FakeBootService { StartBootFailsAtCall = 4 };
-        var orchestrator = new SparkBatchUpdateService(fake);
+        var orchestrator = new SparkBatchUpdateService(fake, postBlocksSettle: TimeSpan.Zero, postEndSettle: TimeSpan.Zero);
         var items = SparkAreas.All
             .Select(a => new SparkBatchItem(a.Area, Fw))
             .ToList();
@@ -134,7 +135,7 @@ public class SparkBatchUpdateServiceTests
     {
         // 6th UploadBlocksOnly call = Rostrum, last area in canonical order.
         var fake = new FakeBootService { UploadBlocksFailsAtCall = 6 };
-        var orchestrator = new SparkBatchUpdateService(fake);
+        var orchestrator = new SparkBatchUpdateService(fake, postBlocksSettle: TimeSpan.Zero, postEndSettle: TimeSpan.Zero);
         var items = SparkAreas.All
             .Select(a => new SparkBatchItem(a.Area, Fw))
             .ToList();
@@ -151,7 +152,7 @@ public class SparkBatchUpdateServiceTests
     {
         // 5th EndBoot call = Motor2 in canonical order.
         var fake = new FakeBootService { EndBootFailsAtCall = 5 };
-        var orchestrator = new SparkBatchUpdateService(fake);
+        var orchestrator = new SparkBatchUpdateService(fake, postBlocksSettle: TimeSpan.Zero, postEndSettle: TimeSpan.Zero);
         var items = SparkAreas.All
             .Select(a => new SparkBatchItem(a.Area, Fw))
             .ToList();
@@ -171,7 +172,7 @@ public class SparkBatchUpdateServiceTests
         // (Motor2), so the first area must complete fully and the third must
         // never be StartBoot-ed.
         var fake = new FakeBootService { UploadBlocksFailsAtCall = 2 };
-        var orchestrator = new SparkBatchUpdateService(fake);
+        var orchestrator = new SparkBatchUpdateService(fake, postBlocksSettle: TimeSpan.Zero, postEndSettle: TimeSpan.Zero);
         var items = new List<SparkBatchItem>
         {
             new(SparkFirmwareArea.Motor1, Fw),
@@ -213,7 +214,7 @@ public class SparkBatchUpdateServiceTests
         // restart out of RunAreaAsync and emit exactly one CMD_RESTART_MACHINE
         // (recipient = HMI) after the last area completes.
         var fake = new FakeBootService();
-        var orchestrator = new SparkBatchUpdateService(fake);
+        var orchestrator = new SparkBatchUpdateService(fake, postBlocksSettle: TimeSpan.Zero, postEndSettle: TimeSpan.Zero);
         var items = new List<SparkBatchItem>
         {
             new(SparkFirmwareArea.HmiApplication, Fw),
@@ -238,7 +239,7 @@ public class SparkBatchUpdateServiceTests
         // First item has zero-length firmware → precondition must reject
         // BEFORE any device call, regardless of the rest of the batch.
         var fake = new FakeBootService();
-        var orchestrator = new SparkBatchUpdateService(fake);
+        var orchestrator = new SparkBatchUpdateService(fake, postBlocksSettle: TimeSpan.Zero, postEndSettle: TimeSpan.Zero);
         var offendingArea = SparkFirmwareArea.Motor1;
         var items = new List<SparkBatchItem>
         {
@@ -258,7 +259,7 @@ public class SparkBatchUpdateServiceTests
     public async Task ExecuteAsync_RaisesAreaStartedAndCompletedEvents()
     {
         var fake = new FakeBootService();
-        var orchestrator = new SparkBatchUpdateService(fake);
+        var orchestrator = new SparkBatchUpdateService(fake, postBlocksSettle: TimeSpan.Zero, postEndSettle: TimeSpan.Zero);
         var startedAreas = new List<SparkFirmwareArea>();
         var completedAreas = new List<SparkFirmwareArea>();
         orchestrator.AreaStarted += (_, a) => startedAreas.Add(a.Area);
@@ -281,7 +282,7 @@ public class SparkBatchUpdateServiceTests
     public async Task ExecuteAsync_AreaProgress_TaggedWithCurrentArea()
     {
         var fake = new FakeBootService();
-        var orchestrator = new SparkBatchUpdateService(fake);
+        var orchestrator = new SparkBatchUpdateService(fake, postBlocksSettle: TimeSpan.Zero, postEndSettle: TimeSpan.Zero);
         var observed = new List<SparkAreaProgress>();
         orchestrator.AreaProgress += (_, p) => observed.Add(p);
         // Fake will emit a single progress event during UploadBlocksOnlyAsync.


### PR DESCRIPTION
## What

The SPARK **batch** firmware update bricked the ECUs (Motor1/Motor2/Rostrum) to `v0.0.0.0`, while the HMI application/images flashed fine. Root cause: the batch fired `CMD_RESTART_MACHINE` **~3 ms** after the `CMD_END_PROCEDURE` reply. `END` triggers the target board's image finalize (close flash session, write validity marker, switch boot vector), which takes a few seconds; rebooting mid-finalize leaves the ECU image invalid. The HMI survives because it's the board the soft restart reboots; the ECUs don't.

A manual flash that worked left **~3.4 s** between the `END` reply and the restart (a human dismissing a dialog) — that dwell was the commit window.

## Fix

`SparkBatchUpdateService` now waits a configurable **commit settle** (default 5 s; ctor params `postBlocksSettle`/`postEndSettle`; no-op at `TimeSpan.Zero` so tests don't real-sleep): one after the last block before `END` (per area), one after `END` before the single end-of-batch `RESTART_MACHINE`.

## Validation

- Bench (Egicon SN 2225998): **two consecutive clean full 5-area batches** (HMI app + images + Motor1 + Motor2 + Rostrum), no battery pull — ECUs came up at the correct versions.
- `dotnet test`: **937 green** (364 net10.0 / 573 net10.0-windows); settles no-op in tests (~26 s suite).

## Review focus

- `Services/Boot/SparkBatchUpdateService.cs` — the two `SettleAsync` waits + the constructor params.
- Test call sites pass `TimeSpan.Zero` (no real sleeps in CI).

## Docs added

- `Docs/SPARK_BATCH_COMMANDS.md` — exact command sequence, first-page erase wait, settle.
- `Docs/SPARK_BATCH_OPERATOR_NOTES.md` — file identification by work-code, what's normal during a flash, recovery.

## Release

The second commit cuts **v0.4.4** (patch) — bumps `Directory.Build.props` and moves CHANGELOG `[Unreleased]` → `[0.4.4]`, bundling this fix with the already-pending `CanPort` #127 fix and `PCANManager` `IAsyncDisposable`. After merge, tag `v0.4.4` to trigger the release workflow.

## Out of scope

The `Can:AutoStart` toggle (bench convenience) is **deferred** to a later release.
