### PR TITLE
feat: switch CAN baudrate at runtime from the menu

### DIFF
--- a/GUI.Windows/Forms/Form1.cs
+++ b/GUI.Windows/Forms/Form1.cs
@@ -26,6 +26,11 @@ namespace StemPC
         // propaga ConnectionStatusChanged al port.
         private readonly SerialPortManager _serialPortManager;
         private readonly BLEManager _bleManager;
+        // Referenziato come tipo concreto per il cambio bitrate CAN a runtime dal menu:
+        // ChangeBaudRate è CAN-specifico e non vive sul contratto ICommunicationPort.
+        // È lo stesso singleton usato da ConnectionManager, quindi il nuovo bitrate vale
+        // per il canale attivo.
+        private readonly CanPort _canPort;
         private readonly ILogger<Form1> _logger;
 
         // Single-sourced from the assembly version (Directory.Build.props
@@ -112,6 +117,7 @@ namespace StemPC
             _variantConfig = serviceProvider.GetRequiredService<IDeviceVariantConfig>();
             _serialPortManager = serviceProvider.GetRequiredService<SerialPortManager>();
             _bleManager = serviceProvider.GetRequiredService<BLEManager>();
+            _canPort = serviceProvider.GetRequiredService<CanPort>();
             _logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<Form1>();
 
             // Canale hardware di default dalla variante.
@@ -737,21 +743,33 @@ namespace StemPC
             }
         }
 
-        // I 4 handler baudrate (100/125/250/500 kbps) mantengono il switch a CAN ma non
-        // applicano più runtime change del baudrate: col nuovo stack PCAN il bitrate è
-        // configurato alla creazione di CanPort. TODO: esporre baudrate runtime via CanPort
-        // se serve (ora fix 250kbps).
+        // I 4 handler baudrate applicano il bitrate CAN selezionato (100/125/250/500 kbps)
+        // sul driver PCAN e poi attivano il canale CAN. ChangeBaudRate reinizializza il
+        // canale PEAK al nuovo bitrate.
         private async void toolStripMenuItem2_Click(object? sender, EventArgs e)
-            => await SwitchChannelAsync(ChannelKind.Can);
+            => await SetCanBaudRateAsync(100);
 
         private async void toolStripMenuItem3_Click(object? sender, EventArgs e)
-            => await SwitchChannelAsync(ChannelKind.Can);
+            => await SetCanBaudRateAsync(250);
 
         private async void kbpsToolStripMenuItem1_Click(object? sender, EventArgs e)
-            => await SwitchChannelAsync(ChannelKind.Can);
+            => await SetCanBaudRateAsync(125);
 
         private async void kbpsToolStripMenuItem_Click(object? sender, EventArgs e)
-            => await SwitchChannelAsync(ChannelKind.Can);
+            => await SetCanBaudRateAsync(500);
+
+        /// <summary>
+        /// Applies the selected CAN bitrate on the PCAN driver, then activates the CAN
+        /// channel. The driver-side reinit briefly blocks, so it runs off the UI thread.
+        /// </summary>
+        private async Task SetCanBaudRateAsync(int baudRateKbps)
+        {
+            var ok = await Task.Run(() => _canPort.ChangeBaudRate(baudRateKbps));
+            if (!ok)
+                _logger.LogWarning(
+                    "CAN baud rate change to {BaudRateKbps} kbps failed", baudRateKbps);
+            await SwitchChannelAsync(ChannelKind.Can);
+        }
 
         /// <summary>
         /// Attiva il canale indicato tramite <see cref="ConnectionManager.SwitchToAsync"/>,

--- a/Infrastructure.Protocol/Hardware/CanPort.cs
+++ b/Infrastructure.Protocol/Hardware/CanPort.cs
@@ -127,6 +127,19 @@ public sealed class CanPort : ICommunicationPort
         await _driver.SendMessageAsync(arbitrationId, data, isExtended: true);
     }
 
+    /// <summary>
+    /// Reconfigures the underlying CAN channel bitrate at runtime by forwarding
+    /// to the driver. CAN-specific, so it lives on <see cref="CanPort"/> rather
+    /// than on the channel-agnostic <see cref="ICommunicationPort"/> contract.
+    /// </summary>
+    /// <param name="baudRateKbps">Bus bitrate in kbit/s (100, 125, 250, or 500).</param>
+    /// <returns><c>true</c> if the driver reinitialized at the new bitrate.</returns>
+    public bool ChangeBaudRate(int baudRateKbps)
+    {
+        ThrowIfDisposed();
+        return _driver.ChangeBaudRate(baudRateKbps);
+    }
+
     /// <inheritdoc/>
     public void Dispose()
     {

--- a/Infrastructure.Protocol/Hardware/IPcanDriver.cs
+++ b/Infrastructure.Protocol/Hardware/IPcanDriver.cs
@@ -21,6 +21,13 @@ public interface IPcanDriver
     /// </summary>
     Task<bool> SendMessageAsync(uint canId, byte[] data, bool isExtended);
 
+    /// <summary>
+    /// Reconfigures the CAN channel bitrate at runtime.
+    /// </summary>
+    /// <param name="baudRateKbps">Bus bitrate in kbit/s (100, 125, 250, or 500).</param>
+    /// <returns><c>true</c> if the channel was reinitialized at the new bitrate.</returns>
+    bool ChangeBaudRate(int baudRateKbps);
+
     /// <summary>Chiude il canale PCAN.</summary>
     void Disconnect();
 }

--- a/Infrastructure.Protocol/Hardware/PCANManager.cs
+++ b/Infrastructure.Protocol/Hardware/PCANManager.cs
@@ -165,32 +165,34 @@ public class PCANManager : IPcanDriver, IAsyncDisposable
     }
 
     /// <summary>
+    /// Maps a bus bitrate in kbit/s (100, 125, 250, or 500) to the matching
+    /// <see cref="TPCANBaudrate"/>. Pure, so it is unit-testable without touching
+    /// the native PCAN driver.
+    /// </summary>
+    /// <returns><c>true</c> for a supported bitrate; <c>false</c> otherwise.</returns>
+    public static bool TryMapBaudRate(int baudRateKbps, out TPCANBaudrate baudRate)
+    {
+        switch (baudRateKbps)
+        {
+            case 100: baudRate = TPCANBaudrate.PCAN_BAUD_100K; return true;
+            case 125: baudRate = TPCANBaudrate.PCAN_BAUD_125K; return true;
+            case 250: baudRate = TPCANBaudrate.PCAN_BAUD_250K; return true;
+            case 500: baudRate = TPCANBaudrate.PCAN_BAUD_500K; return true;
+            default: baudRate = default; return false;
+        }
+    }
+
+    /// <summary>
     /// Cambia il baud rate del canale CAN a runtime
     /// </summary>
     /// <param name="newBaudRateKbps">Baud rate in kbps (100, 125, 250, 500)</param>
     /// <returns>True se il cambio è avvenuto con successo, False altrimenti</returns>
     public bool ChangeBaudRate(int newBaudRateKbps)
     {
-        TPCANBaudrate newBaudRate;
-
-        // Converti il valore in kbps nell'enum TPCANBaudrate
-        switch (newBaudRateKbps)
+        if (!TryMapBaudRate(newBaudRateKbps, out var newBaudRate))
         {
-            case 100000:
-                newBaudRate = TPCANBaudrate.PCAN_BAUD_100K;
-                break;
-            case 125000:
-                newBaudRate = TPCANBaudrate.PCAN_BAUD_125K;
-                break;
-            case 250000:
-                newBaudRate = TPCANBaudrate.PCAN_BAUD_250K;
-                break;
-            case 500000:
-                newBaudRate = TPCANBaudrate.PCAN_BAUD_500K;
-                break;
-            default:
-                ErrorOccurred?.Invoke(this, $"Baud rate non supportato: {newBaudRateKbps} kbps. Valori validi: 100, 125, 250, 500");
-                return false;
+            ErrorOccurred?.Invoke(this, $"Baud rate non supportato: {newBaudRateKbps} kbps. Valori validi: 100, 125, 250, 500");
+            return false;
         }
 
         try

--- a/Tests/Unit/Infrastructure/Protocol/CanPortTests.cs
+++ b/Tests/Unit/Infrastructure/Protocol/CanPortTests.cs
@@ -248,6 +248,46 @@ public class CanPortTests
         Assert.Equal(8, driver.SentMessages[0].Data.Length);
     }
 
+    // --- ChangeBaudRate: forwarding al driver ---
+
+    [Fact]
+    public void ChangeBaudRate_ForwardsKbpsToDriver_ReturnsDriverResult()
+    {
+        var driver = new FakePcanDriver { IsConnected = true };
+        using var port = new CanPort(driver);
+
+        var ok = port.ChangeBaudRate(500);
+
+        Assert.True(ok);
+        Assert.Equal(new[] { 500 }, driver.BaudRateChanges);
+    }
+
+    [Fact]
+    public void ChangeBaudRate_DriverReportsFailure_ReturnsFalse()
+    {
+        var driver = new FakePcanDriver
+        {
+            IsConnected = true,
+            ChangeBaudRateResult = _ => false,
+        };
+        using var port = new CanPort(driver);
+
+        var ok = port.ChangeBaudRate(250);
+
+        Assert.False(ok);
+        Assert.Equal(new[] { 250 }, driver.BaudRateChanges);
+    }
+
+    [Fact]
+    public void AfterDispose_ChangeBaudRate_ThrowsObjectDisposed()
+    {
+        var driver = new FakePcanDriver { IsConnected = true };
+        var port = new CanPort(driver);
+        port.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => port.ChangeBaudRate(500));
+    }
+
     // --- PacketReceived: convention payload ---
 
     [Fact]

--- a/Tests/Unit/Infrastructure/Protocol/FakePcanDriver.cs
+++ b/Tests/Unit/Infrastructure/Protocol/FakePcanDriver.cs
@@ -18,10 +18,20 @@ internal sealed class FakePcanDriver : IPcanDriver
     public Func<uint, byte[], bool, bool> SendResult { get; set; } = (_, _, _) => true;
     public int DisconnectCount { get; private set; }
 
+    /// <summary>kbit/s values passed to <see cref="ChangeBaudRate"/>, in call order.</summary>
+    public List<int> BaudRateChanges { get; } = [];
+    public Func<int, bool> ChangeBaudRateResult { get; set; } = _ => true;
+
     public Task<bool> SendMessageAsync(uint canId, byte[] data, bool isExtended)
     {
         SentMessages.Add((canId, data, isExtended));
         return Task.FromResult(SendResult(canId, data, isExtended));
+    }
+
+    public bool ChangeBaudRate(int baudRateKbps)
+    {
+        BaudRateChanges.Add(baudRateKbps);
+        return ChangeBaudRateResult(baudRateKbps);
     }
 
     public void Disconnect()

--- a/Tests/Unit/Infrastructure/Protocol/PCANManagerTests.cs
+++ b/Tests/Unit/Infrastructure/Protocol/PCANManagerTests.cs
@@ -1,0 +1,38 @@
+using Infrastructure.Protocol.Hardware;
+using Peak.Can.Basic.BackwardCompatibility;
+
+namespace Tests.Unit.Infrastructure.Protocol;
+
+/// <summary>
+/// Tests for <see cref="PCANManager.TryMapBaudRate"/>, the pure kbit/s → enum
+/// mapping. The manager itself P/Invokes the native PCAN driver and cannot be
+/// constructed on a driver-less host, but the mapping is side-effect-free.
+/// </summary>
+public class PCANManagerTests
+{
+    [Theory]
+    [InlineData(100, TPCANBaudrate.PCAN_BAUD_100K)]
+    [InlineData(125, TPCANBaudrate.PCAN_BAUD_125K)]
+    [InlineData(250, TPCANBaudrate.PCAN_BAUD_250K)]
+    [InlineData(500, TPCANBaudrate.PCAN_BAUD_500K)]
+    public void TryMapBaudRate_SupportedKbps_MapsToEnum(int kbps, TPCANBaudrate expected)
+    {
+        var ok = PCANManager.TryMapBaudRate(kbps, out var baudRate);
+
+        Assert.True(ok);
+        Assert.Equal(expected, baudRate);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1000)]
+    // 500000 is bps, not kbps — the pre-fix switch wrongly accepted it while
+    // rejecting the documented 500. This guards against that regression.
+    [InlineData(500000)]
+    public void TryMapBaudRate_UnsupportedValue_ReturnsFalse(int value)
+    {
+        var ok = PCANManager.TryMapBaudRate(value, out _);
+
+        Assert.False(ok);
+    }
+}


### PR DESCRIPTION
## What

The CAN baudrate menu items (100/125/250/500 Kbps) previously only switched the active channel to CAN and ignored the chosen bitrate; the PCAN driver stayed at its DI-constructed default (100K). Each item now reconfigures the bus bitrate on the driver, then activates the CAN channel.

## Changes

- `IPcanDriver` gains `ChangeBaudRate(int kbps)`; `CanPort` forwards to it (CAN-specific, so it stays off the channel-agnostic `ICommunicationPort` contract).
- Fix `PCANManager`'s kbps->TPCANBaudrate mapping: the switch cased bps (100000..) while the parameter, docs and error string all said kbps, so `ChangeBaudRate(500)` fell through to unsupported. Extracted a pure, unit-testable `TryMapBaudRate` helper and routed both call sites through it.
- `Form1` resolves the `CanPort` singleton (same instance `ConnectionManager` uses) and applies the bitrate off the UI thread, since the driver reinit briefly blocks.

## Tests

- RED watched first, then GREEN. New: `CanPort.ChangeBaudRate` forwarding + dispose, `PCANManagerTests` mapping (the 500000-bps case guards the exact bug fixed).
- net10.0-windows: 583 passed; net10.0: 364 passed; Release build clean.

## Review focus

- `CanPort.ChangeBaudRate` boundary placement (concrete port vs interface).
- Off-UI-thread reinit in `Form1.SetCanBaudRateAsync`.

## Not covered

Live PCAN reinit path (PCANBasic.Uninitialize/Initialize at the new bitrate) needs a PEAK device on the bench; unit tests cover forwarding + mapping only.